### PR TITLE
Add missing filters arguments for servers jobs list endpoint

### DIFF
--- a/dedicated_server.go
+++ b/dedicated_server.go
@@ -727,6 +727,15 @@ func (dsa DedicatedServerApi) ListJobs(serverId string, args ...int) (*Dedicated
 	if len(args) >= 2 {
 		v.Add("limit", fmt.Sprint(args[1]))
 	}
+	if len(args) >= 3 {
+		v.Add("type", fmt.Sprint(args[2]))
+	}
+	if len(args) >= 4 {
+		v.Add("status", fmt.Sprint(args[3]))
+	}
+	if len(args) >= 5 {
+		v.Add("isRunning", fmt.Sprint(args[4]))
+	}
 
 	result := &DedicatedServerJobs{}
 	path := dsa.getPath("/servers/" + serverId + "/jobs?" + v.Encode())


### PR DESCRIPTION
Now added to https://developer.leaseweb.com/api-docs/dedicatedservers_v2.html#operation/servers-jobs-list

In reply to comment from https://github.com/LeaseWeb/terraform-provider-leaseweb/pull/1