### PR TITLE
Add Context parameter to all API request functions

### DIFF
--- a/abuse.go
+++ b/abuse.go
@@ -1,6 +1,7 @@
 package leaseweb
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -73,7 +74,7 @@ func (aba AbuseApi) getPath(endpoint string) string {
 	return "/abuse/" + ABUSE_API_VERSION + endpoint
 }
 
-func (aba AbuseApi) List(args ...interface{}) (*AbuseReports, error) {
+func (aba AbuseApi) List(ctx context.Context, args ...interface{}) (*AbuseReports, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -92,22 +93,22 @@ func (aba AbuseApi) List(args ...interface{}) (*AbuseReports, error) {
 
 	path := aba.getPath("/reports?" + v.Encode())
 	result := &AbuseReports{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (aba AbuseApi) Get(abuseReportId string) (*AbuseReport, error) {
+func (aba AbuseApi) Get(ctx context.Context, abuseReportId string) (*AbuseReport, error) {
 	path := aba.getPath("/reports/" + abuseReportId)
 	result := &AbuseReport{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (aba AbuseApi) ListMessages(abuseReportId string, args ...int) (*AbuseMessages, error) {
+func (aba AbuseApi) ListMessages(ctx context.Context, abuseReportId string, args ...int) (*AbuseMessages, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -118,35 +119,35 @@ func (aba AbuseApi) ListMessages(abuseReportId string, args ...int) (*AbuseMessa
 
 	path := aba.getPath("/reports/" + abuseReportId + "/messages" + v.Encode())
 	result := &AbuseMessages{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (aba AbuseApi) CreateMessage(abuseReportId string, body string) ([]string, error) {
+func (aba AbuseApi) CreateMessage(ctx context.Context, abuseReportId string, body string) ([]string, error) {
 	var result []string
 	payload := map[string]string{body: body}
 	path := aba.getPath("/reports/" + abuseReportId + "/messages")
-	if err := doRequest(http.MethodPost, path, &result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, &result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (aba AbuseApi) ListResolutionOptions(abuseReportId string) (*AbuseResolutions, error) {
+func (aba AbuseApi) ListResolutionOptions(ctx context.Context, abuseReportId string) (*AbuseResolutions, error) {
 	path := aba.getPath("/reports/" + abuseReportId + "/resolutions")
 	result := &AbuseResolutions{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (aba AbuseApi) Resolve(abuseReportId string, resolutions []string) error {
+func (aba AbuseApi) Resolve(ctx context.Context, abuseReportId string, resolutions []string) error {
 	payload := map[string][]string{"resolutions": resolutions}
 	path := aba.getPath("/reports/" + abuseReportId + "/resolve")
-	return doRequest(http.MethodPost, path, nil, payload)
+	return doRequest(ctx, http.MethodPost, path, nil, payload)
 }
 
 // TODO

--- a/abuse_test.go
+++ b/abuse_test.go
@@ -1,6 +1,7 @@
 package leaseweb
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -40,7 +41,8 @@ func TestAbuseList(t *testing.T) {
 	defer teardown()
 
 	abuseApi := AbuseApi{}
-	response, err := abuseApi.List()
+	ctx := context.Background()
+	response, err := abuseApi.List(ctx)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -94,7 +96,8 @@ func TestAbuseListPaginateAndPassStatuses(t *testing.T) {
 
 	abuseApi := AbuseApi{}
 
-	response, err := abuseApi.List(1, [2]string{"OPEN", "WAITING"})
+	ctx := context.Background()
+	response, err := abuseApi.List(ctx, 1, [2]string{"OPEN", "WAITING"})
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -124,7 +127,8 @@ func TestAbuseListBeEmpty(t *testing.T) {
 	defer teardown()
 
 	abuseApi := AbuseApi{}
-	response, err := abuseApi.List()
+	ctx := context.Background()
+	response, err := abuseApi.List(ctx)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -145,7 +149,8 @@ func TestAbuseListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return AbuseApi{}.List()
+				ctx := context.Background()
+				return AbuseApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "ACCESS_DENIED",
@@ -161,7 +166,8 @@ func TestAbuseListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return AbuseApi{}.List()
+				ctx := context.Background()
+				return AbuseApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "SERVER_ERROR",
@@ -177,7 +183,8 @@ func TestAbuseListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return AbuseApi{}.List()
+				ctx := context.Background()
+				return AbuseApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "TEMPORARILY_UNAVAILABLE",
@@ -245,7 +252,8 @@ func TestAbuseGet(t *testing.T) {
 	defer teardown()
 
 	abuseApi := AbuseApi{}
-	response, err := abuseApi.Get("000005")
+	ctx := context.Background()
+	response, err := abuseApi.Get(ctx, "000005")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -296,7 +304,8 @@ func TestAbuseGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return AbuseApi{}.Get("wrong-id")
+				ctx := context.Background()
+				return AbuseApi{}.Get(ctx, "wrong-id")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "ACCESS_DENIED",
@@ -312,7 +321,8 @@ func TestAbuseGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return AbuseApi{}.Get("123456")
+				ctx := context.Background()
+				return AbuseApi{}.Get(ctx, "123456")
 			},
 			ExpectedError: ApiError{},
 		},
@@ -325,7 +335,8 @@ func TestAbuseGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return AbuseApi{}.Get("123456")
+				ctx := context.Background()
+				return AbuseApi{}.Get(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "SERVER_ERROR",
@@ -341,7 +352,8 @@ func TestAbuseGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return AbuseApi{}.Get("123456")
+				ctx := context.Background()
+				return AbuseApi{}.Get(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "TEMPORARILY_UNAVAILABLE",
@@ -377,7 +389,8 @@ func TestAbuseListMessages(t *testing.T) {
 	defer teardown()
 
 	abuseApi := AbuseApi{}
-	response, err := abuseApi.ListMessages("123456789")
+	ctx := context.Background()
+	response, err := abuseApi.ListMessages(ctx, "123456789")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -421,7 +434,8 @@ func TestAbuseListMessagesPaginate(t *testing.T) {
 	defer teardown()
 
 	abuseApi := AbuseApi{}
-	response, err := abuseApi.ListMessages("123456789", 1)
+	ctx := context.Background()
+	response, err := abuseApi.ListMessages(ctx, "123456789", 1)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -449,7 +463,8 @@ func TestAbuseListMessagesBeEmpty(t *testing.T) {
 	defer teardown()
 
 	abuseApi := AbuseApi{}
-	response, err := abuseApi.ListMessages("123456789")
+	ctx := context.Background()
+	response, err := abuseApi.ListMessages(ctx, "123456789")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -470,7 +485,8 @@ func TestAbuseListMessagesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return AbuseApi{}.ListMessages("123456789")
+				ctx := context.Background()
+				return AbuseApi{}.ListMessages(ctx, "123456789")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "ACCESS_DENIED",
@@ -486,7 +502,8 @@ func TestAbuseListMessagesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return AbuseApi{}.ListMessages("123456789")
+				ctx := context.Background()
+				return AbuseApi{}.ListMessages(ctx, "123456789")
 			},
 			ExpectedError: ApiError{},
 		},
@@ -499,7 +516,8 @@ func TestAbuseListMessagesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return AbuseApi{}.ListMessages("123456789")
+				ctx := context.Background()
+				return AbuseApi{}.ListMessages(ctx, "123456789")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "SERVER_ERROR",
@@ -515,7 +533,8 @@ func TestAbuseListMessagesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return AbuseApi{}.ListMessages("123456789")
+				ctx := context.Background()
+				return AbuseApi{}.ListMessages(ctx, "123456789")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "TEMPORARILY_UNAVAILABLE",
@@ -536,7 +555,8 @@ func TestAbuseCreateMessage(t *testing.T) {
 	defer teardown()
 
 	abuseApi := AbuseApi{}
-	resp, err := abuseApi.CreateMessage("123456789", "message body...")
+	ctx := context.Background()
+	resp, err := abuseApi.CreateMessage(ctx, "123456789", "message body...")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -554,7 +574,8 @@ func TestAbuseCreateMessageServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return AbuseApi{}.CreateMessage("123456789", "message body...")
+				ctx := context.Background()
+				return AbuseApi{}.CreateMessage(ctx, "123456789", "message body...")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "ACCESS_DENIED",
@@ -570,7 +591,8 @@ func TestAbuseCreateMessageServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return AbuseApi{}.CreateMessage("123456789", "message body...")
+				ctx := context.Background()
+				return AbuseApi{}.CreateMessage(ctx, "123456789", "message body...")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "SERVER_ERROR",
@@ -586,7 +608,8 @@ func TestAbuseCreateMessageServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return AbuseApi{}.CreateMessage("123456789", "message body...")
+				ctx := context.Background()
+				return AbuseApi{}.CreateMessage(ctx, "123456789", "message body...")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "TEMPORARILY_UNAVAILABLE",
@@ -623,7 +646,8 @@ func TestAbuseListResolutionOptions(t *testing.T) {
 	defer teardown()
 
 	abuseApi := AbuseApi{}
-	response, err := abuseApi.ListResolutionOptions("123456789")
+	ctx := context.Background()
+	response, err := abuseApi.ListResolutionOptions(ctx, "123456789")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -642,7 +666,8 @@ func TestAbuseListResolutionOptionsBeEmpty(t *testing.T) {
 	defer teardown()
 
 	abuseApi := AbuseApi{}
-	response, err := abuseApi.ListResolutionOptions("123456789")
+	ctx := context.Background()
+	response, err := abuseApi.ListResolutionOptions(ctx, "123456789")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -660,7 +685,8 @@ func TestAbuseListResolutionOptionsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return AbuseApi{}.ListResolutionOptions("123456789")
+				ctx := context.Background()
+				return AbuseApi{}.ListResolutionOptions(ctx, "123456789")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "ACCESS_DENIED",
@@ -676,7 +702,8 @@ func TestAbuseListResolutionOptionsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return AbuseApi{}.ListResolutionOptions("123456789")
+				ctx := context.Background()
+				return AbuseApi{}.ListResolutionOptions(ctx, "123456789")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "SERVER_ERROR",
@@ -692,7 +719,8 @@ func TestAbuseListResolutionOptionsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return AbuseApi{}.ListResolutionOptions("123456789")
+				ctx := context.Background()
+				return AbuseApi{}.ListResolutionOptions(ctx, "123456789")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "TEMPORARILY_UNAVAILABLE",
@@ -712,7 +740,8 @@ func TestAbuseResolve(t *testing.T) {
 	defer teardown()
 
 	abuseApi := AbuseApi{}
-	err := abuseApi.Resolve("123456789", []string{"CONTENT_REMOVED", "SUSPENDED"})
+	ctx := context.Background()
+	err := abuseApi.Resolve(ctx, "123456789", []string{"CONTENT_REMOVED", "SUSPENDED"})
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -729,7 +758,8 @@ func TestAbuseResolveServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, AbuseApi{}.Resolve("123456789", []string{"CONTENT_REMOVED", "SUSPENDED"})
+				ctx := context.Background()
+				return nil, AbuseApi{}.Resolve(ctx, "123456789", []string{"CONTENT_REMOVED", "SUSPENDED"})
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "ACCESS_DENIED",
@@ -745,7 +775,8 @@ func TestAbuseResolveServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, AbuseApi{}.Resolve("123456789", []string{"CONTENT_REMOVED", "SUSPENDED"})
+				ctx := context.Background()
+				return nil, AbuseApi{}.Resolve(ctx, "123456789", []string{"CONTENT_REMOVED", "SUSPENDED"})
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "SERVER_ERROR",
@@ -761,7 +792,8 @@ func TestAbuseResolveServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, AbuseApi{}.Resolve("123456789", []string{"CONTENT_REMOVED", "SUSPENDED"})
+				ctx := context.Background()
+				return nil, AbuseApi{}.Resolve(ctx, "123456789", []string{"CONTENT_REMOVED", "SUSPENDED"})
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "TEMPORARILY_UNAVAILABLE",

--- a/customer_account.go
+++ b/customer_account.go
@@ -1,6 +1,7 @@
 package leaseweb
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -56,22 +57,22 @@ func (cai CustomerAccountApi) getPath(endpoint string) string {
 	return "/account/" + CUSTOMER_ACCOUNT_API_VERSION + endpoint
 }
 
-func (cai CustomerAccountApi) Get() (*CustomerAccount, error) {
+func (cai CustomerAccountApi) Get(ctx context.Context) (*CustomerAccount, error) {
 	path := cai.getPath("/details")
 	result := &CustomerAccount{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (cai CustomerAccountApi) Update(ad CustomerAccountAddress) error {
+func (cai CustomerAccountApi) Update(ctx context.Context, ad CustomerAccountAddress) error {
 	path := cai.getPath("/details")
 	payload := map[string]CustomerAccountAddress{"address": ad}
-	return doRequest(http.MethodPut, path, nil, payload)
+	return doRequest(ctx, http.MethodPut, path, nil, payload)
 }
 
-func (cai CustomerAccountApi) ListContacts(args ...interface{}) (*CustomerAccountContacts, error) {
+func (cai CustomerAccountApi) ListContacts(ctx context.Context, args ...interface{}) (*CustomerAccountContacts, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -90,36 +91,36 @@ func (cai CustomerAccountApi) ListContacts(args ...interface{}) (*CustomerAccoun
 
 	path := cai.getPath("/contacts?" + v.Encode())
 	result := &CustomerAccountContacts{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (cai CustomerAccountApi) CreateContact(newContact CustomerAccountContact) (*CustomerAccountContact, error) {
+func (cai CustomerAccountApi) CreateContact(ctx context.Context, newContact CustomerAccountContact) (*CustomerAccountContact, error) {
 	path := cai.getPath("/contacts")
 	result := &CustomerAccountContact{}
-	if err := doRequest(http.MethodPost, path, result, newContact); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result, newContact); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (cai CustomerAccountApi) DeleteContact(contactId string) error {
+func (cai CustomerAccountApi) DeleteContact(ctx context.Context, contactId string) error {
 	path := cai.getPath("/contacts/" + contactId)
-	return doRequest(http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path)
 }
 
-func (cai CustomerAccountApi) GetContact(contactId string) (*CustomerAccountContact, error) {
+func (cai CustomerAccountApi) GetContact(ctx context.Context, contactId string) (*CustomerAccountContact, error) {
 	path := cai.getPath("/contacts/" + contactId)
 	result := &CustomerAccountContact{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (cai CustomerAccountApi) UpdateContact(contactId string, phone CustomerAccountPhone, roles []string, args ...interface{}) error {
+func (cai CustomerAccountApi) UpdateContact(ctx context.Context, contactId string, phone CustomerAccountPhone, roles []string, args ...interface{}) error {
 	payload := make(map[string]interface{})
 	payload["phone"] = phone
 	payload["roles"] = roles
@@ -131,11 +132,11 @@ func (cai CustomerAccountApi) UpdateContact(contactId string, phone CustomerAcco
 	}
 
 	path := cai.getPath("/contacts" + contactId)
-	return doRequest(http.MethodPut, path, nil, payload)
+	return doRequest(ctx, http.MethodPut, path, nil, payload)
 }
 
-func (cai CustomerAccountApi) AssignPrimaryRolesToContact(contactId string, roles []string) error {
+func (cai CustomerAccountApi) AssignPrimaryRolesToContact(ctx context.Context, contactId string, roles []string) error {
 	payload := map[string][]string{"roles": roles}
 	path := cai.getPath("/contacts" + contactId)
-	return doRequest(http.MethodPost, path, nil, payload)
+	return doRequest(ctx, http.MethodPost, path, nil, payload)
 }

--- a/customer_account_test.go
+++ b/customer_account_test.go
@@ -1,6 +1,7 @@
 package leaseweb
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -30,7 +31,8 @@ func TestCustomerAccountGet(t *testing.T) {
 	defer teardown()
 
 	customerAccountApi := CustomerAccountApi{}
-	response, err := customerAccountApi.Get()
+	ctx := context.Background()
+	response, err := customerAccountApi.Get(ctx)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -58,7 +60,8 @@ func TestCustomerAccountGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return CustomerAccountApi{}.Get()
+				ctx := context.Background()
+				return CustomerAccountApi{}.Get(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -75,7 +78,8 @@ func TestCustomerAccountGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return CustomerAccountApi{}.Get()
+				ctx := context.Background()
+				return CustomerAccountApi{}.Get(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -92,7 +96,8 @@ func TestCustomerAccountGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return CustomerAccountApi{}.Get()
+				ctx := context.Background()
+				return CustomerAccountApi{}.Get(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -109,7 +114,8 @@ func TestCustomerAccountGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return CustomerAccountApi{}.Get()
+				ctx := context.Background()
+				return CustomerAccountApi{}.Get(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -130,7 +136,8 @@ func TestCustomerAccountUpdate(t *testing.T) {
 	defer teardown()
 
 	customerAccountApi := CustomerAccountApi{}
-	err := customerAccountApi.Update(CustomerAccountAddress{City: "amsterdam", HouseNumber: "800", PostalCode: "1105 AB", Street: "Hessenbergweg"})
+	ctx := context.Background()
+	err := customerAccountApi.Update(ctx, CustomerAccountAddress{City: "amsterdam", HouseNumber: "800", PostalCode: "1105 AB", Street: "Hessenbergweg"})
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -147,7 +154,8 @@ func TestCustomerAccountUpdateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, CustomerAccountApi{}.Update(CustomerAccountAddress{City: "amsterdam", HouseNumber: "800", PostalCode: "1105 AB", Street: "Hessenbergweg"})
+				ctx := context.Background()
+				return nil, CustomerAccountApi{}.Update(ctx, CustomerAccountAddress{City: "amsterdam", HouseNumber: "800", PostalCode: "1105 AB", Street: "Hessenbergweg"})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -164,7 +172,8 @@ func TestCustomerAccountUpdateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, CustomerAccountApi{}.Update(CustomerAccountAddress{City: "amsterdam", HouseNumber: "800", PostalCode: "1105 AB", Street: "Hessenbergweg"})
+				ctx := context.Background()
+				return nil, CustomerAccountApi{}.Update(ctx, CustomerAccountAddress{City: "amsterdam", HouseNumber: "800", PostalCode: "1105 AB", Street: "Hessenbergweg"})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -181,7 +190,8 @@ func TestCustomerAccountUpdateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "405", "errorMessage": "AccountDetails modifications are not permitted for USA residents, please contact support for any modification request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, CustomerAccountApi{}.Update(CustomerAccountAddress{City: "amsterdam", HouseNumber: "800", PostalCode: "1105 AB", Street: "Hessenbergweg"})
+				ctx := context.Background()
+				return nil, CustomerAccountApi{}.Update(ctx, CustomerAccountAddress{City: "amsterdam", HouseNumber: "800", PostalCode: "1105 AB", Street: "Hessenbergweg"})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -198,7 +208,8 @@ func TestCustomerAccountUpdateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, CustomerAccountApi{}.Update(CustomerAccountAddress{City: "amsterdam", HouseNumber: "800", PostalCode: "1105 AB", Street: "Hessenbergweg"})
+				ctx := context.Background()
+				return nil, CustomerAccountApi{}.Update(ctx, CustomerAccountAddress{City: "amsterdam", HouseNumber: "800", PostalCode: "1105 AB", Street: "Hessenbergweg"})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -215,7 +226,8 @@ func TestCustomerAccountUpdateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, CustomerAccountApi{}.Update(CustomerAccountAddress{City: "amsterdam", HouseNumber: "800", PostalCode: "1105 AB", Street: "Hessenbergweg"})
+				ctx := context.Background()
+				return nil, CustomerAccountApi{}.Update(ctx, CustomerAccountAddress{City: "amsterdam", HouseNumber: "800", PostalCode: "1105 AB", Street: "Hessenbergweg"})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -265,7 +277,8 @@ func TestCustomerAccountListContacts(t *testing.T) {
 	defer teardown()
 
 	customerAccountApi := CustomerAccountApi{}
-	resp, err := customerAccountApi.ListContacts()
+	ctx := context.Background()
+	resp, err := customerAccountApi.ListContacts(ctx)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -330,7 +343,8 @@ func TestCustomerAccountListContactsPaginateAndFilter(t *testing.T) {
 	defer teardown()
 
 	customerAccountApi := CustomerAccountApi{}
-	resp, err := customerAccountApi.ListContacts(1, 5, []string{"GENERAL", "SECURITY", "TECHNICAL", "BILLING"})
+	ctx := context.Background()
+	resp, err := customerAccountApi.ListContacts(ctx, 1, 5, []string{"GENERAL", "SECURITY", "TECHNICAL", "BILLING"})
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -367,7 +381,8 @@ func TestCustomerAccountListContactsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return CustomerAccountApi{}.ListContacts()
+				ctx := context.Background()
+				return CustomerAccountApi{}.ListContacts(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -384,7 +399,8 @@ func TestCustomerAccountListContactsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return CustomerAccountApi{}.ListContacts()
+				ctx := context.Background()
+				return CustomerAccountApi{}.ListContacts(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -401,7 +417,8 @@ func TestCustomerAccountListContactsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return CustomerAccountApi{}.ListContacts()
+				ctx := context.Background()
+				return CustomerAccountApi{}.ListContacts(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -418,7 +435,8 @@ func TestCustomerAccountListContactsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return CustomerAccountApi{}.ListContacts()
+				ctx := context.Background()
+				return CustomerAccountApi{}.ListContacts(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -466,7 +484,8 @@ func TestCustomerAccountCreateContact(t *testing.T) {
 		Mobile:      CustomerAccountPhone{CountryCode: "NL", Number: "682212341"},
 		Phone:       CustomerAccountPhone{CountryCode: "NL", Number: "682212342"},
 	}
-	resp, err := customerAccountApi.CreateContact(newContact)
+	ctx := context.Background()
+	resp, err := customerAccountApi.CreateContact(ctx, newContact)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -502,7 +521,8 @@ func TestCustomerAccountCreateContactServerErrors(t *testing.T) {
 					Mobile:      CustomerAccountPhone{CountryCode: "NL", Number: "682212341"},
 					Phone:       CustomerAccountPhone{CountryCode: "NL", Number: "682212342"},
 				}
-				return CustomerAccountApi{}.CreateContact(newContact)
+				ctx := context.Background()
+				return CustomerAccountApi{}.CreateContact(ctx, newContact)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -528,7 +548,8 @@ func TestCustomerAccountCreateContactServerErrors(t *testing.T) {
 					Mobile:      CustomerAccountPhone{CountryCode: "NL", Number: "682212341"},
 					Phone:       CustomerAccountPhone{CountryCode: "NL", Number: "682212342"},
 				}
-				return CustomerAccountApi{}.CreateContact(newContact)
+				ctx := context.Background()
+				return CustomerAccountApi{}.CreateContact(ctx, newContact)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -554,7 +575,8 @@ func TestCustomerAccountCreateContactServerErrors(t *testing.T) {
 					Mobile:      CustomerAccountPhone{CountryCode: "NL", Number: "682212341"},
 					Phone:       CustomerAccountPhone{CountryCode: "NL", Number: "682212342"},
 				}
-				return CustomerAccountApi{}.CreateContact(newContact)
+				ctx := context.Background()
+				return CustomerAccountApi{}.CreateContact(ctx, newContact)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -580,7 +602,8 @@ func TestCustomerAccountCreateContactServerErrors(t *testing.T) {
 					Mobile:      CustomerAccountPhone{CountryCode: "NL", Number: "682212341"},
 					Phone:       CustomerAccountPhone{CountryCode: "NL", Number: "682212342"},
 				}
-				return CustomerAccountApi{}.CreateContact(newContact)
+				ctx := context.Background()
+				return CustomerAccountApi{}.CreateContact(ctx, newContact)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -601,7 +624,8 @@ func TestCustomerAccountDeleteContact(t *testing.T) {
 	defer teardown()
 
 	customerAccountApi := CustomerAccountApi{}
-	err := customerAccountApi.DeleteContact("contact-id")
+	ctx := context.Background()
+	err := customerAccountApi.DeleteContact(ctx, "contact-id")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -618,7 +642,8 @@ func TestCustomerAccountDeleteContactServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, CustomerAccountApi{}.DeleteContact("contact-id")
+				ctx := context.Background()
+				return nil, CustomerAccountApi{}.DeleteContact(ctx, "contact-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -635,7 +660,8 @@ func TestCustomerAccountDeleteContactServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, CustomerAccountApi{}.DeleteContact("contact-id")
+				ctx := context.Background()
+				return nil, CustomerAccountApi{}.DeleteContact(ctx, "contact-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -652,7 +678,8 @@ func TestCustomerAccountDeleteContactServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, CustomerAccountApi{}.DeleteContact("contact-id")
+				ctx := context.Background()
+				return nil, CustomerAccountApi{}.DeleteContact(ctx, "contact-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -669,7 +696,8 @@ func TestCustomerAccountDeleteContactServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, CustomerAccountApi{}.DeleteContact("contact-id")
+				ctx := context.Background()
+				return nil, CustomerAccountApi{}.DeleteContact(ctx, "contact-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -718,7 +746,8 @@ func TestCustomerAccountGetContact(t *testing.T) {
 	defer teardown()
 
 	customerAccountApi := CustomerAccountApi{}
-	response, err := customerAccountApi.GetContact("contact-id")
+	ctx := context.Background()
+	response, err := customerAccountApi.GetContact(ctx, "contact-id")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -748,7 +777,8 @@ func TestCustomerAccountGetContactServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return CustomerAccountApi{}.GetContact("contact-id")
+				ctx := context.Background()
+				return CustomerAccountApi{}.GetContact(ctx, "contact-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -765,7 +795,8 @@ func TestCustomerAccountGetContactServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return CustomerAccountApi{}.GetContact("contact-id")
+				ctx := context.Background()
+				return CustomerAccountApi{}.GetContact(ctx, "contact-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -782,7 +813,8 @@ func TestCustomerAccountGetContactServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return CustomerAccountApi{}.GetContact("contact-id")
+				ctx := context.Background()
+				return CustomerAccountApi{}.GetContact(ctx, "contact-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -799,7 +831,8 @@ func TestCustomerAccountGetContactServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return CustomerAccountApi{}.GetContact("contact-id")
+				ctx := context.Background()
+				return CustomerAccountApi{}.GetContact(ctx, "contact-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -820,7 +853,9 @@ func TestCustomerAccountUpdateContact(t *testing.T) {
 	defer teardown()
 
 	customerAccountApi := CustomerAccountApi{}
+	ctx := context.Background()
 	err := customerAccountApi.UpdateContact(
+		ctx,
 		"contact-id",
 		CustomerAccountPhone{CountryCode: "NL", Number: "653388213"},
 		[]string{"GENERAL", "TECHNICAL"},
@@ -842,7 +877,9 @@ func TestCustomerAccountUpdateContactServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
+				ctx := context.Background()
 				return nil, CustomerAccountApi{}.UpdateContact(
+					ctx,
 					"contact-id",
 					CustomerAccountPhone{CountryCode: "NL", Number: "653388213"},
 					[]string{"GENERAL", "TECHNICAL"},
@@ -865,7 +902,9 @@ func TestCustomerAccountUpdateContactServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
+				ctx := context.Background()
 				return nil, CustomerAccountApi{}.UpdateContact(
+					ctx,
 					"contact-id",
 					CustomerAccountPhone{CountryCode: "NL", Number: "653388213"},
 					[]string{"GENERAL", "TECHNICAL"},
@@ -888,7 +927,9 @@ func TestCustomerAccountUpdateContactServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
+				ctx := context.Background()
 				return nil, CustomerAccountApi{}.UpdateContact(
+					ctx,
 					"contact-id",
 					CustomerAccountPhone{CountryCode: "NL", Number: "653388213"},
 					[]string{"GENERAL", "TECHNICAL"},
@@ -911,7 +952,9 @@ func TestCustomerAccountUpdateContactServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
+				ctx := context.Background()
 				return nil, CustomerAccountApi{}.UpdateContact(
+					ctx,
 					"contact-id",
 					CustomerAccountPhone{CountryCode: "NL", Number: "653388213"},
 					[]string{"GENERAL", "TECHNICAL"},
@@ -934,7 +977,9 @@ func TestCustomerAccountUpdateContactServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
+				ctx := context.Background()
 				return nil, CustomerAccountApi{}.UpdateContact(
+					ctx,
 					"contact-id",
 					CustomerAccountPhone{CountryCode: "NL", Number: "653388213"},
 					[]string{"GENERAL", "TECHNICAL"},
@@ -961,7 +1006,9 @@ func TestCustomerAccountAssignPrimaryRolesToContact(t *testing.T) {
 	defer teardown()
 
 	customerAccountApi := CustomerAccountApi{}
+	ctx := context.Background()
 	err := customerAccountApi.AssignPrimaryRolesToContact(
+		ctx,
 		"contact-id",
 		[]string{"GENERAL", "TECHNICAL"},
 	)
@@ -980,7 +1027,9 @@ func TestCustomerAccountAssignPrimaryRolesToContactServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
+				ctx := context.Background()
 				return nil, CustomerAccountApi{}.AssignPrimaryRolesToContact(
+					ctx,
 					"contact-id",
 					[]string{"GENERAL", "TECHNICAL"},
 				)
@@ -1000,7 +1049,9 @@ func TestCustomerAccountAssignPrimaryRolesToContactServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
+				ctx := context.Background()
 				return nil, CustomerAccountApi{}.AssignPrimaryRolesToContact(
+					ctx,
 					"contact-id",
 					[]string{"GENERAL", "TECHNICAL"},
 				)
@@ -1020,7 +1071,9 @@ func TestCustomerAccountAssignPrimaryRolesToContactServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
+				ctx := context.Background()
 				return nil, CustomerAccountApi{}.AssignPrimaryRolesToContact(
+					ctx,
 					"contact-id",
 					[]string{"GENERAL", "TECHNICAL"},
 				)
@@ -1040,7 +1093,9 @@ func TestCustomerAccountAssignPrimaryRolesToContactServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
+				ctx := context.Background()
 				return nil, CustomerAccountApi{}.AssignPrimaryRolesToContact(
+					ctx,
 					"contact-id",
 					[]string{"GENERAL", "TECHNICAL"},
 				)
@@ -1060,7 +1115,9 @@ func TestCustomerAccountAssignPrimaryRolesToContactServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
+				ctx := context.Background()
 				return nil, CustomerAccountApi{}.AssignPrimaryRolesToContact(
+					ctx,
 					"contact-id",
 					[]string{"GENERAL", "TECHNICAL"},
 				)

--- a/dedicated_network_equipment.go
+++ b/dedicated_network_equipment.go
@@ -1,6 +1,7 @@
 package leaseweb
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -43,7 +44,7 @@ func (dnea DedicatedNetworkEquipmentApi) getPath(endpoint string) string {
 	return "/bareMetals/" + DEDICATED_NETWORK_EQUIPMENT_API_VERSION + endpoint
 }
 
-func (dnea DedicatedNetworkEquipmentApi) List(args ...interface{}) (*DedicatedNetworkEquipments, error) {
+func (dnea DedicatedNetworkEquipmentApi) List(ctx context.Context, args ...interface{}) (*DedicatedNetworkEquipments, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -72,28 +73,28 @@ func (dnea DedicatedNetworkEquipmentApi) List(args ...interface{}) (*DedicatedNe
 
 	path := dnea.getPath("/networkEquipments?" + v.Encode())
 	result := &DedicatedNetworkEquipments{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dnea DedicatedNetworkEquipmentApi) Get(networkEquipmentId string) (*DedicatedNetworkEquipment, error) {
+func (dnea DedicatedNetworkEquipmentApi) Get(ctx context.Context, networkEquipmentId string) (*DedicatedNetworkEquipment, error) {
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId)
 	result := &DedicatedNetworkEquipment{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dnea DedicatedNetworkEquipmentApi) Update(networkEquipmentId, reference string) error {
+func (dnea DedicatedNetworkEquipmentApi) Update(ctx context.Context, networkEquipmentId, reference string) error {
 	payload := map[string]string{"reference": reference}
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId)
-	return doRequest(http.MethodPut, path, nil, payload)
+	return doRequest(ctx, http.MethodPut, path, nil, payload)
 }
 
-func (dnea DedicatedNetworkEquipmentApi) ListIps(networkEquipmentId string, args ...interface{}) (*Ips, error) {
+func (dnea DedicatedNetworkEquipmentApi) ListIps(ctx context.Context, networkEquipmentId string, args ...interface{}) (*Ips, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -116,49 +117,49 @@ func (dnea DedicatedNetworkEquipmentApi) ListIps(networkEquipmentId string, args
 
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/ips" + v.Encode())
 	result := &Ips{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dnea DedicatedNetworkEquipmentApi) GetIp(networkEquipmentId, ip string) (*Ip, error) {
+func (dnea DedicatedNetworkEquipmentApi) GetIp(ctx context.Context, networkEquipmentId, ip string) (*Ip, error) {
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/ips/" + ip)
 	result := &Ip{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dnea DedicatedNetworkEquipmentApi) UpdateIp(networkEquipmentId, ip string, payload map[string]string) (*Ip, error) {
+func (dnea DedicatedNetworkEquipmentApi) UpdateIp(ctx context.Context, networkEquipmentId, ip string, payload map[string]string) (*Ip, error) {
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/ips/" + ip)
 	result := &Ip{}
-	if err := doRequest(http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dnea DedicatedNetworkEquipmentApi) NullRouteAnIp(networkEquipmentId, ip string) (*Ip, error) {
+func (dnea DedicatedNetworkEquipmentApi) NullRouteAnIp(ctx context.Context, networkEquipmentId, ip string) (*Ip, error) {
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/ips/" + ip + "/null")
 	result := &Ip{}
-	if err := doRequest(http.MethodPost, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dnea DedicatedNetworkEquipmentApi) RemoveNullRouteAnIp(networkEquipmentId, ip string) (*Ip, error) {
+func (dnea DedicatedNetworkEquipmentApi) RemoveNullRouteAnIp(ctx context.Context, networkEquipmentId, ip string) (*Ip, error) {
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/ips/" + ip + "/unnull")
 	result := &Ip{}
-	if err := doRequest(http.MethodPost, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dnea DedicatedNetworkEquipmentApi) ListNullRoutes(networkEquipmentId string, args ...interface{}) (*NullRoutes, error) {
+func (dnea DedicatedNetworkEquipmentApi) ListNullRoutes(ctx context.Context, networkEquipmentId string, args ...interface{}) (*NullRoutes, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -169,13 +170,13 @@ func (dnea DedicatedNetworkEquipmentApi) ListNullRoutes(networkEquipmentId strin
 
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/nullRouteHistory?" + v.Encode())
 	result := &NullRoutes{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dnea DedicatedNetworkEquipmentApi) ListCredentials(networkEquipmentId string, args ...int) (*Credentials, error) {
+func (dnea DedicatedNetworkEquipmentApi) ListCredentials(ctx context.Context, networkEquipmentId string, args ...int) (*Credentials, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -186,26 +187,26 @@ func (dnea DedicatedNetworkEquipmentApi) ListCredentials(networkEquipmentId stri
 
 	result := &Credentials{}
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/credentials?" + v.Encode())
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dnea DedicatedNetworkEquipmentApi) CreateCredential(networkEquipmentId, credentialType, username, password string) (*Credential, error) {
+func (dnea DedicatedNetworkEquipmentApi) CreateCredential(ctx context.Context, networkEquipmentId, credentialType, username, password string) (*Credential, error) {
 	result := &Credential{}
 	payload := make(map[string]string)
 	payload["type"] = credentialType
 	payload["username"] = username
 	payload["password"] = password
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/credentials")
-	if err := doRequest(http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dnea DedicatedNetworkEquipmentApi) ListCredentialsByType(networkEquipmentId, credentialType string, args ...int) (*Credentials, error) {
+func (dnea DedicatedNetworkEquipmentApi) ListCredentialsByType(ctx context.Context, networkEquipmentId, credentialType string, args ...int) (*Credentials, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -216,56 +217,56 @@ func (dnea DedicatedNetworkEquipmentApi) ListCredentialsByType(networkEquipmentI
 
 	result := &Credentials{}
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/credentials/" + credentialType + "?" + v.Encode())
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dnea DedicatedNetworkEquipmentApi) GetCredential(networkEquipmentId, credentialType, username string) (*Credential, error) {
+func (dnea DedicatedNetworkEquipmentApi) GetCredential(ctx context.Context, networkEquipmentId, credentialType, username string) (*Credential, error) {
 	result := &Credential{}
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/credentials/" + credentialType + "/" + username)
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dnea DedicatedNetworkEquipmentApi) DeleteCredential(networkEquipmentId, credentialType, username string) error {
+func (dnea DedicatedNetworkEquipmentApi) DeleteCredential(ctx context.Context, networkEquipmentId, credentialType, username string) error {
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/credentials/" + credentialType + "/" + username)
-	return doRequest(http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path)
 }
 
-func (dnea DedicatedNetworkEquipmentApi) UpdateCredential(networkEquipmentId, credentialType, username, password string) (*Credential, error) {
+func (dnea DedicatedNetworkEquipmentApi) UpdateCredential(ctx context.Context, networkEquipmentId, credentialType, username, password string) (*Credential, error) {
 	result := &Credential{}
 	payload := map[string]string{"password": password}
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/credentials/" + credentialType + "/" + username)
-	if err := doRequest(http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dnea DedicatedNetworkEquipmentApi) PowerCycleServer(networkEquipmentId string) error {
+func (dnea DedicatedNetworkEquipmentApi) PowerCycleServer(ctx context.Context, networkEquipmentId string) error {
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/powerCycle")
-	return doRequest(http.MethodPost, path)
+	return doRequest(ctx, http.MethodPost, path)
 }
 
-func (dnea DedicatedNetworkEquipmentApi) GetPowerStatus(networkEquipmentId string) (*PowerStatus, error) {
+func (dnea DedicatedNetworkEquipmentApi) GetPowerStatus(ctx context.Context, networkEquipmentId string) (*PowerStatus, error) {
 	result := &PowerStatus{}
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/powerInfo")
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dnea DedicatedNetworkEquipmentApi) PowerOffServer(networkEquipmentId string) error {
+func (dnea DedicatedNetworkEquipmentApi) PowerOffServer(ctx context.Context, networkEquipmentId string) error {
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/powerOff")
-	return doRequest(http.MethodPost, path)
+	return doRequest(ctx, http.MethodPost, path)
 }
 
-func (dnea DedicatedNetworkEquipmentApi) PowerOnServer(networkEquipmentId string) error {
+func (dnea DedicatedNetworkEquipmentApi) PowerOnServer(ctx context.Context, networkEquipmentId string) error {
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/powerOn")
-	return doRequest(http.MethodPost, path)
+	return doRequest(ctx, http.MethodPost, path)
 }

--- a/dedicated_network_equipment_test.go
+++ b/dedicated_network_equipment_test.go
@@ -1,6 +1,7 @@
 package leaseweb
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -112,7 +113,8 @@ func TestDedicatedNetworkEquipmentList(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedNetworkEquipmentApi{}.List()
+	ctx := context.Background()
+	response, err := DedicatedNetworkEquipmentApi{}.List(ctx)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 2)
@@ -188,7 +190,8 @@ func TestDedicatedNetworkEquipmentListBeEmpty(t *testing.T) {
 		fmt.Fprintf(w, `{"_metadata":{"limit": 10, "offset": 0, "totalCount": 0}, "networkEquipments": []}`)
 	})
 	defer teardown()
-	response, err := DedicatedNetworkEquipmentApi{}.List()
+	ctx := context.Background()
+	response, err := DedicatedNetworkEquipmentApi{}.List(ctx)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 0)
@@ -257,7 +260,8 @@ func TestDedicatedNetworkEquipmentListPaginateAndFilter(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedNetworkEquipmentApi{}.List(1)
+	ctx := context.Background()
+	response, err := DedicatedNetworkEquipmentApi{}.List(ctx, 1)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 11)
@@ -307,7 +311,8 @@ func TestDedicatedNetworkEquipmentListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.List()
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -324,7 +329,8 @@ func TestDedicatedNetworkEquipmentListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.List()
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -341,7 +347,8 @@ func TestDedicatedNetworkEquipmentListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.List()
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -358,7 +365,8 @@ func TestDedicatedNetworkEquipmentListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.List()
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -456,7 +464,8 @@ func TestDedicatedNetworkEquipmentGet(t *testing.T) {
 	})
 	defer teardown()
 
-	NetworkEquipment, err := DedicatedNetworkEquipmentApi{}.Get("12345")
+	ctx := context.Background()
+	NetworkEquipment, err := DedicatedNetworkEquipmentApi{}.Get(ctx, "12345")
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -525,7 +534,8 @@ func TestDedicatedNetworkEquipmentGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.Get("12345")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.Get(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -542,7 +552,8 @@ func TestDedicatedNetworkEquipmentGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.Get("12345")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.Get(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -559,7 +570,8 @@ func TestDedicatedNetworkEquipmentGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.Get("12345")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.Get(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -576,7 +588,8 @@ func TestDedicatedNetworkEquipmentGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.Get("12345")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.Get(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -596,7 +609,8 @@ func TestDedicatedNetworkEquipmentUpdate(t *testing.T) {
 	})
 	defer teardown()
 
-	err := DedicatedNetworkEquipmentApi{}.Update("2893829", "new reference")
+	ctx := context.Background()
+	err := DedicatedNetworkEquipmentApi{}.Update(ctx, "2893829", "new reference")
 	assert := assert.New(t)
 	assert.Nil(err)
 }
@@ -612,7 +626,8 @@ func TestDedicatedNetworkEquipmentUpdateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedNetworkEquipmentApi{}.Update("2893829", "new reference")
+				ctx := context.Background()
+				return nil, DedicatedNetworkEquipmentApi{}.Update(ctx, "2893829", "new reference")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -629,7 +644,8 @@ func TestDedicatedNetworkEquipmentUpdateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedNetworkEquipmentApi{}.Update("2893829", "new reference")
+				ctx := context.Background()
+				return nil, DedicatedNetworkEquipmentApi{}.Update(ctx, "2893829", "new reference")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -646,7 +662,8 @@ func TestDedicatedNetworkEquipmentUpdateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedNetworkEquipmentApi{}.Update("2893829", "new reference")
+				ctx := context.Background()
+				return nil, DedicatedNetworkEquipmentApi{}.Update(ctx, "2893829", "new reference")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -663,7 +680,8 @@ func TestDedicatedNetworkEquipmentUpdateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedNetworkEquipmentApi{}.Update("2893829", "new reference")
+				ctx := context.Background()
+				return nil, DedicatedNetworkEquipmentApi{}.Update(ctx, "2893829", "new reference")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -719,7 +737,8 @@ func TestDedicatedNetworkEquipmentListIps(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedNetworkEquipmentApi{}.ListIps("server-id")
+	ctx := context.Background()
+	response, err := DedicatedNetworkEquipmentApi{}.ListIps(ctx, "server-id")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 2)
@@ -759,7 +778,8 @@ func TestDedicatedNetworkEquipmentListIpsBeEmpty(t *testing.T) {
 		fmt.Fprintf(w, `{"_metadata":{"limit": 10, "offset": 0, "totalCount": 0}, "ips": []}`)
 	})
 	defer teardown()
-	response, err := DedicatedNetworkEquipmentApi{}.ListIps("server-id")
+	ctx := context.Background()
+	response, err := DedicatedNetworkEquipmentApi{}.ListIps(ctx, "server-id")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 0)
@@ -798,7 +818,8 @@ func TestDedicatedNetworkEquipmentListIpsFilterAndPagination(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedNetworkEquipmentApi{}.ListIps("server-id", 1, 10)
+	ctx := context.Background()
+	response, err := DedicatedNetworkEquipmentApi{}.ListIps(ctx, "server-id", 1, 10)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 11)
@@ -830,7 +851,8 @@ func TestDedicatedNetworkEquipmentListIpsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.ListIps("server-id")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.ListIps(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -847,7 +869,8 @@ func TestDedicatedNetworkEquipmentListIpsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.ListIps("server-id")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.ListIps(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -864,7 +887,8 @@ func TestDedicatedNetworkEquipmentListIpsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.ListIps("server-id")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.ListIps(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -881,7 +905,8 @@ func TestDedicatedNetworkEquipmentListIpsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.ListIps("server-id")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.ListIps(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -914,7 +939,8 @@ func TestDedicatedNetworkEquipmentGetIp(t *testing.T) {
 	})
 	defer teardown()
 
-	Ip, err := DedicatedNetworkEquipmentApi{}.GetIp("12345", "127.0.0.6")
+	ctx := context.Background()
+	Ip, err := DedicatedNetworkEquipmentApi{}.GetIp(ctx, "12345", "127.0.0.6")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(Ip.DDOS.DetectionProfile, "ADVANCED_LOW_UDP")
@@ -940,7 +966,8 @@ func TestDedicatedNetworkEquipmentGetIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.GetIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.GetIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -957,7 +984,8 @@ func TestDedicatedNetworkEquipmentGetIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.GetIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.GetIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -974,7 +1002,8 @@ func TestDedicatedNetworkEquipmentGetIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.GetIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.GetIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -991,7 +1020,8 @@ func TestDedicatedNetworkEquipmentGetIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.GetIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.GetIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1008,7 +1038,8 @@ func TestDedicatedNetworkEquipmentGetIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.GetIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.GetIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1042,7 +1073,8 @@ func TestDedicatedNetworkEquipmentUpdateIp(t *testing.T) {
 	defer teardown()
 
 	payload := map[string]string{"detectionProfile": "ADVANCED_DEFAULT", "reverseLookup": "domain.example.com"}
-	Ip, err := DedicatedNetworkEquipmentApi{}.UpdateIp("12345", "127.0.0.6", payload)
+	ctx := context.Background()
+	Ip, err := DedicatedNetworkEquipmentApi{}.UpdateIp(ctx, "12345", "127.0.0.6", payload)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(Ip.DDOS.DetectionProfile, "ADVANCED_DEFAULT")
@@ -1069,7 +1101,8 @@ func TestDedicatedNetworkEquipmentUpdateIpServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"detectionProfile": "ADVANCED_DEFAULT", "reverseLookup": "domain.example.com"}
-				return DedicatedNetworkEquipmentApi{}.UpdateIp("12345", "127.0.0.6", payload)
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.UpdateIp(ctx, "12345", "127.0.0.6", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1087,7 +1120,8 @@ func TestDedicatedNetworkEquipmentUpdateIpServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"detectionProfile": "ADVANCED_DEFAULT", "reverseLookup": "domain.example.com"}
-				return DedicatedNetworkEquipmentApi{}.UpdateIp("12345", "127.0.0.6", payload)
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.UpdateIp(ctx, "12345", "127.0.0.6", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1105,7 +1139,8 @@ func TestDedicatedNetworkEquipmentUpdateIpServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"detectionProfile": "ADVANCED_DEFAULT", "reverseLookup": "domain.example.com"}
-				return DedicatedNetworkEquipmentApi{}.UpdateIp("12345", "127.0.0.6", payload)
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.UpdateIp(ctx, "12345", "127.0.0.6", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1123,7 +1158,8 @@ func TestDedicatedNetworkEquipmentUpdateIpServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"detectionProfile": "ADVANCED_DEFAULT", "reverseLookup": "domain.example.com"}
-				return DedicatedNetworkEquipmentApi{}.UpdateIp("12345", "127.0.0.6", payload)
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.UpdateIp(ctx, "12345", "127.0.0.6", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1141,7 +1177,8 @@ func TestDedicatedNetworkEquipmentUpdateIpServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"detectionProfile": "ADVANCED_DEFAULT", "reverseLookup": "domain.example.com"}
-				return DedicatedNetworkEquipmentApi{}.UpdateIp("12345", "127.0.0.6", payload)
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.UpdateIp(ctx, "12345", "127.0.0.6", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1174,7 +1211,8 @@ func TestDedicatedNetworkEquipmentNullRouteAnIp(t *testing.T) {
 	})
 	defer teardown()
 
-	Ip, err := DedicatedNetworkEquipmentApi{}.NullRouteAnIp("12345", "127.0.0.6")
+	ctx := context.Background()
+	Ip, err := DedicatedNetworkEquipmentApi{}.NullRouteAnIp(ctx, "12345", "127.0.0.6")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(Ip.DDOS.DetectionProfile, "ADVANCED_DEFAULT")
@@ -1200,7 +1238,8 @@ func TestDedicatedNetworkEquipmentNullRouteAnIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.NullRouteAnIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.NullRouteAnIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1217,7 +1256,8 @@ func TestDedicatedNetworkEquipmentNullRouteAnIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.NullRouteAnIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.NullRouteAnIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1234,7 +1274,8 @@ func TestDedicatedNetworkEquipmentNullRouteAnIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.NullRouteAnIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.NullRouteAnIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1251,7 +1292,8 @@ func TestDedicatedNetworkEquipmentNullRouteAnIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.NullRouteAnIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.NullRouteAnIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1268,7 +1310,8 @@ func TestDedicatedNetworkEquipmentNullRouteAnIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.NullRouteAnIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.NullRouteAnIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1301,7 +1344,8 @@ func TestDedicatedNetworkEquipmentRemoveNullRouteAnIp(t *testing.T) {
 	})
 	defer teardown()
 
-	Ip, err := DedicatedNetworkEquipmentApi{}.RemoveNullRouteAnIp("12345", "127.0.0.6")
+	ctx := context.Background()
+	Ip, err := DedicatedNetworkEquipmentApi{}.RemoveNullRouteAnIp(ctx, "12345", "127.0.0.6")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(Ip.DDOS.DetectionProfile, "ADVANCED_DEFAULT")
@@ -1327,7 +1371,8 @@ func TestDedicatedNetworkEquipmentRemoveNullRouteAnIpServerErrors(t *testing.T) 
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.RemoveNullRouteAnIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.RemoveNullRouteAnIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1344,7 +1389,8 @@ func TestDedicatedNetworkEquipmentRemoveNullRouteAnIpServerErrors(t *testing.T) 
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.RemoveNullRouteAnIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.RemoveNullRouteAnIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1361,7 +1407,8 @@ func TestDedicatedNetworkEquipmentRemoveNullRouteAnIpServerErrors(t *testing.T) 
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.RemoveNullRouteAnIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.RemoveNullRouteAnIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1378,7 +1425,8 @@ func TestDedicatedNetworkEquipmentRemoveNullRouteAnIpServerErrors(t *testing.T) 
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.RemoveNullRouteAnIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.RemoveNullRouteAnIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1395,7 +1443,8 @@ func TestDedicatedNetworkEquipmentRemoveNullRouteAnIpServerErrors(t *testing.T) 
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.RemoveNullRouteAnIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.RemoveNullRouteAnIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1431,7 +1480,8 @@ func TestDedicatedNetworkEquipmentListNullRoutes(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedNetworkEquipmentApi{}.ListNullRoutes("server-id")
+	ctx := context.Background()
+	response, err := DedicatedNetworkEquipmentApi{}.ListNullRoutes(ctx, "server-id")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 1)
@@ -1455,7 +1505,8 @@ func TestDedicatedNetworkEquipmentListNullRoutesBeEmpty(t *testing.T) {
 		fmt.Fprintf(w, `{"_metadata":{"limit": 10, "offset": 0, "totalCount": 0}, "nullRoutes": []}`)
 	})
 	defer teardown()
-	response, err := DedicatedNetworkEquipmentApi{}.ListNullRoutes("server-id")
+	ctx := context.Background()
+	response, err := DedicatedNetworkEquipmentApi{}.ListNullRoutes(ctx, "server-id")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 0)
@@ -1488,7 +1539,8 @@ func TestDedicatedNetworkEquipmentListNullRoutesFilterAndPagination(t *testing.T
 	})
 	defer teardown()
 
-	response, err := DedicatedNetworkEquipmentApi{}.ListNullRoutes("server-id", 1)
+	ctx := context.Background()
+	response, err := DedicatedNetworkEquipmentApi{}.ListNullRoutes(ctx, "server-id", 1)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 11)
@@ -1516,7 +1568,8 @@ func TestDedicatedNetworkEquipmentListNullRoutesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.ListNullRoutes("server-id")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.ListNullRoutes(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1533,7 +1586,8 @@ func TestDedicatedNetworkEquipmentListNullRoutesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.ListNullRoutes("server-id")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.ListNullRoutes(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1550,7 +1604,8 @@ func TestDedicatedNetworkEquipmentListNullRoutesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.ListNullRoutes("server-id")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.ListNullRoutes(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1567,7 +1622,8 @@ func TestDedicatedNetworkEquipmentListNullRoutesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.ListNullRoutes("server-id")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.ListNullRoutes(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1611,7 +1667,8 @@ func TestDedicatedNetworkEquipmentListCredentials(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedNetworkEquipmentApi{}.ListCredentials("99944")
+	ctx := context.Background()
+	response, err := DedicatedNetworkEquipmentApi{}.ListCredentials(ctx, "99944")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 4)
@@ -1636,7 +1693,8 @@ func TestDedicatedNetworkEquipmentListCredentialsBeEmpty(t *testing.T) {
 		fmt.Fprintf(w, `{"_metadata":{"limit": 10, "offset": 0, "totalCount": 0}, "credentials": []}`)
 	})
 	defer teardown()
-	response, err := DedicatedNetworkEquipmentApi{}.ListCredentials("99944")
+	ctx := context.Background()
+	response, err := DedicatedNetworkEquipmentApi{}.ListCredentials(ctx, "99944")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 0)
@@ -1665,7 +1723,8 @@ func TestDedicatedNetworkEquipmentListCredentialsPaginate(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedNetworkEquipmentApi{}.ListCredentials("99944")
+	ctx := context.Background()
+	response, err := DedicatedNetworkEquipmentApi{}.ListCredentials(ctx, "99944")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 11)
@@ -1688,7 +1747,8 @@ func TestDedicatedNetworkEquipmentListCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.ListCredentials("99944")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.ListCredentials(ctx, "99944")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1705,7 +1765,8 @@ func TestDedicatedNetworkEquipmentListCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.ListCredentials("99944")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.ListCredentials(ctx, "99944")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1722,7 +1783,8 @@ func TestDedicatedNetworkEquipmentListCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.ListCredentials("99944")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.ListCredentials(ctx, "99944")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1739,7 +1801,8 @@ func TestDedicatedNetworkEquipmentListCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.ListCredentials("99944")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.ListCredentials(ctx, "99944")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1756,7 +1819,8 @@ func TestDedicatedNetworkEquipmentListCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.ListCredentials("99944")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.ListCredentials(ctx, "99944")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1780,7 +1844,8 @@ func TestDedicatedNetworkEquipmentCreateCredential(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := DedicatedNetworkEquipmentApi{}.CreateCredential("12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
+	ctx := context.Background()
+	resp, err := DedicatedNetworkEquipmentApi{}.CreateCredential(ctx, "12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -1800,7 +1865,8 @@ func TestDedicatedNetworkEquipmentCreateCredentialServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.CreateCredential("12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.CreateCredential(ctx, "12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1817,7 +1883,8 @@ func TestDedicatedNetworkEquipmentCreateCredentialServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.CreateCredential("12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.CreateCredential(ctx, "12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1834,7 +1901,8 @@ func TestDedicatedNetworkEquipmentCreateCredentialServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.CreateCredential("12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.CreateCredential(ctx, "12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1851,7 +1919,8 @@ func TestDedicatedNetworkEquipmentCreateCredentialServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.CreateCredential("12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.CreateCredential(ctx, "12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1868,7 +1937,8 @@ func TestDedicatedNetworkEquipmentCreateCredentialServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.CreateCredential("12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.CreateCredential(ctx, "12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1904,7 +1974,8 @@ func TestDedicatedNetworkEquipmentListCredentialsByType(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedNetworkEquipmentApi{}.ListCredentialsByType("99944", "REMOTE_MANAGEMENT")
+	ctx := context.Background()
+	response, err := DedicatedNetworkEquipmentApi{}.ListCredentialsByType(ctx, "99944", "REMOTE_MANAGEMENT")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 2)
@@ -1925,7 +1996,8 @@ func TestDedicatedNetworkEquipmentListCredentialsByTypeBeEmpty(t *testing.T) {
 		fmt.Fprintf(w, `{"_metadata":{"limit": 10, "offset": 0, "totalCount": 0}, "credentials": []}`)
 	})
 	defer teardown()
-	response, err := DedicatedNetworkEquipmentApi{}.ListCredentialsByType("99944", "REMOTE_MANAGEMENT")
+	ctx := context.Background()
+	response, err := DedicatedNetworkEquipmentApi{}.ListCredentialsByType(ctx, "99944", "REMOTE_MANAGEMENT")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 0)
@@ -1954,7 +2026,8 @@ func TestDedicatedNetworkEquipmentListCredentialsByTypePaginate(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedNetworkEquipmentApi{}.ListCredentialsByType("99944", "REMOTE_MANAGEMENT")
+	ctx := context.Background()
+	response, err := DedicatedNetworkEquipmentApi{}.ListCredentialsByType(ctx, "99944", "REMOTE_MANAGEMENT")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 11)
@@ -1977,7 +2050,8 @@ func TestDedicatedNetworkEquipmentListCredentialsByTypeServerErrors(t *testing.T
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.ListCredentialsByType("99944", "REMOTE_MANAGEMENT")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.ListCredentialsByType(ctx, "99944", "REMOTE_MANAGEMENT")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1994,7 +2068,8 @@ func TestDedicatedNetworkEquipmentListCredentialsByTypeServerErrors(t *testing.T
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.ListCredentialsByType("99944", "REMOTE_MANAGEMENT")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.ListCredentialsByType(ctx, "99944", "REMOTE_MANAGEMENT")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2011,7 +2086,8 @@ func TestDedicatedNetworkEquipmentListCredentialsByTypeServerErrors(t *testing.T
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.ListCredentialsByType("99944", "REMOTE_MANAGEMENT")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.ListCredentialsByType(ctx, "99944", "REMOTE_MANAGEMENT")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2028,7 +2104,8 @@ func TestDedicatedNetworkEquipmentListCredentialsByTypeServerErrors(t *testing.T
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.ListCredentialsByType("99944", "REMOTE_MANAGEMENT")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.ListCredentialsByType(ctx, "99944", "REMOTE_MANAGEMENT")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2045,7 +2122,8 @@ func TestDedicatedNetworkEquipmentListCredentialsByTypeServerErrors(t *testing.T
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.ListCredentialsByType("99944", "REMOTE_MANAGEMENT")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.ListCredentialsByType(ctx, "99944", "REMOTE_MANAGEMENT")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2069,7 +2147,8 @@ func TestDedicatedNetworkEquipmentGetCredentials(t *testing.T) {
 	})
 	defer teardown()
 
-	Credential, err := DedicatedNetworkEquipmentApi{}.GetCredential("12345", "OPERATING_SYSTEM", "root")
+	ctx := context.Background()
+	Credential, err := DedicatedNetworkEquipmentApi{}.GetCredential(ctx, "12345", "OPERATING_SYSTEM", "root")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(Credential.Password, "mys3cr3tp@ssw0rd")
@@ -2088,7 +2167,8 @@ func TestDedicatedNetworkEquipmentGetCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.GetCredential("12345", "OPERATING_SYSTEM", "root")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.GetCredential(ctx, "12345", "OPERATING_SYSTEM", "root")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2105,7 +2185,8 @@ func TestDedicatedNetworkEquipmentGetCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.GetCredential("12345", "OPERATING_SYSTEM", "root")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.GetCredential(ctx, "12345", "OPERATING_SYSTEM", "root")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2122,7 +2203,8 @@ func TestDedicatedNetworkEquipmentGetCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.GetCredential("12345", "OPERATING_SYSTEM", "root")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.GetCredential(ctx, "12345", "OPERATING_SYSTEM", "root")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2139,7 +2221,8 @@ func TestDedicatedNetworkEquipmentGetCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.GetCredential("12345", "OPERATING_SYSTEM", "root")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.GetCredential(ctx, "12345", "OPERATING_SYSTEM", "root")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2156,7 +2239,8 @@ func TestDedicatedNetworkEquipmentGetCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.GetCredential("12345", "OPERATING_SYSTEM", "root")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.GetCredential(ctx, "12345", "OPERATING_SYSTEM", "root")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2176,7 +2260,8 @@ func TestDedicatedNetworkEquipmentCredentials(t *testing.T) {
 	})
 	defer teardown()
 
-	err := DedicatedNetworkEquipmentApi{}.DeleteCredential("12345", "OPERATING_SYSTEM", "admin")
+	ctx := context.Background()
+	err := DedicatedNetworkEquipmentApi{}.DeleteCredential(ctx, "12345", "OPERATING_SYSTEM", "admin")
 	assert := assert.New(t)
 	assert.Nil(err)
 }
@@ -2192,7 +2277,8 @@ func TestDedicatedNetworkEquipmentCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedNetworkEquipmentApi{}.DeleteCredential("12345", "OPERATING_SYSTEM", "admin")
+				ctx := context.Background()
+				return nil, DedicatedNetworkEquipmentApi{}.DeleteCredential(ctx, "12345", "OPERATING_SYSTEM", "admin")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2209,7 +2295,8 @@ func TestDedicatedNetworkEquipmentCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedNetworkEquipmentApi{}.DeleteCredential("12345", "OPERATING_SYSTEM", "admin")
+				ctx := context.Background()
+				return nil, DedicatedNetworkEquipmentApi{}.DeleteCredential(ctx, "12345", "OPERATING_SYSTEM", "admin")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2226,7 +2313,8 @@ func TestDedicatedNetworkEquipmentCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedNetworkEquipmentApi{}.DeleteCredential("12345", "OPERATING_SYSTEM", "admin")
+				ctx := context.Background()
+				return nil, DedicatedNetworkEquipmentApi{}.DeleteCredential(ctx, "12345", "OPERATING_SYSTEM", "admin")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2243,7 +2331,8 @@ func TestDedicatedNetworkEquipmentCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedNetworkEquipmentApi{}.DeleteCredential("12345", "OPERATING_SYSTEM", "admin")
+				ctx := context.Background()
+				return nil, DedicatedNetworkEquipmentApi{}.DeleteCredential(ctx, "12345", "OPERATING_SYSTEM", "admin")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2260,7 +2349,8 @@ func TestDedicatedNetworkEquipmentCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedNetworkEquipmentApi{}.DeleteCredential("12345", "OPERATING_SYSTEM", "admin")
+				ctx := context.Background()
+				return nil, DedicatedNetworkEquipmentApi{}.DeleteCredential(ctx, "12345", "OPERATING_SYSTEM", "admin")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2284,7 +2374,8 @@ func TestDedicatedNetworkEquipmentUpdateCredentials(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := DedicatedNetworkEquipmentApi{}.UpdateCredential("12345", "OPERATING_SYSTEM", "admin", "new password")
+	ctx := context.Background()
+	resp, err := DedicatedNetworkEquipmentApi{}.UpdateCredential(ctx, "12345", "OPERATING_SYSTEM", "admin", "new password")
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -2304,7 +2395,8 @@ func TestDedicatedNetworkEquipmentUpdateCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.UpdateCredential("12345", "OPERATING_SYSTEM", "admin", "new password")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.UpdateCredential(ctx, "12345", "OPERATING_SYSTEM", "admin", "new password")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2321,7 +2413,8 @@ func TestDedicatedNetworkEquipmentUpdateCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.UpdateCredential("12345", "OPERATING_SYSTEM", "admin", "new password")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.UpdateCredential(ctx, "12345", "OPERATING_SYSTEM", "admin", "new password")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2338,7 +2431,8 @@ func TestDedicatedNetworkEquipmentUpdateCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.UpdateCredential("12345", "OPERATING_SYSTEM", "admin", "new password")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.UpdateCredential(ctx, "12345", "OPERATING_SYSTEM", "admin", "new password")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2355,7 +2449,8 @@ func TestDedicatedNetworkEquipmentUpdateCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.UpdateCredential("12345", "OPERATING_SYSTEM", "admin", "new password")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.UpdateCredential(ctx, "12345", "OPERATING_SYSTEM", "admin", "new password")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2372,7 +2467,8 @@ func TestDedicatedNetworkEquipmentUpdateCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.UpdateCredential("12345", "OPERATING_SYSTEM", "admin", "new password")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.UpdateCredential(ctx, "12345", "OPERATING_SYSTEM", "admin", "new password")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2392,7 +2488,8 @@ func TestDedicatedNetworkEquipmentPowerCycleServer(t *testing.T) {
 	})
 	defer teardown()
 
-	err := DedicatedNetworkEquipmentApi{}.PowerCycleServer("server id")
+	ctx := context.Background()
+	err := DedicatedNetworkEquipmentApi{}.PowerCycleServer(ctx, "server id")
 	assert := assert.New(t)
 	assert.Nil(err)
 }
@@ -2408,7 +2505,8 @@ func TestDedicatedNetworkEquipmentPowerCycleServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedNetworkEquipmentApi{}.PowerCycleServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedNetworkEquipmentApi{}.PowerCycleServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2425,7 +2523,8 @@ func TestDedicatedNetworkEquipmentPowerCycleServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedNetworkEquipmentApi{}.PowerCycleServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedNetworkEquipmentApi{}.PowerCycleServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2442,7 +2541,8 @@ func TestDedicatedNetworkEquipmentPowerCycleServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedNetworkEquipmentApi{}.PowerCycleServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedNetworkEquipmentApi{}.PowerCycleServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2459,7 +2559,8 @@ func TestDedicatedNetworkEquipmentPowerCycleServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedNetworkEquipmentApi{}.PowerCycleServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedNetworkEquipmentApi{}.PowerCycleServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2476,7 +2577,8 @@ func TestDedicatedNetworkEquipmentPowerCycleServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedNetworkEquipmentApi{}.PowerCycleServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedNetworkEquipmentApi{}.PowerCycleServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2496,7 +2598,8 @@ func TestDedicatedNetworkEquipmentPowerOffServer(t *testing.T) {
 	})
 	defer teardown()
 
-	err := DedicatedNetworkEquipmentApi{}.PowerOffServer("server id")
+	ctx := context.Background()
+	err := DedicatedNetworkEquipmentApi{}.PowerOffServer(ctx, "server id")
 	assert := assert.New(t)
 	assert.Nil(err)
 }
@@ -2512,7 +2615,8 @@ func TestDedicatedNetworkEquipmentPowerOffServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedNetworkEquipmentApi{}.PowerOffServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedNetworkEquipmentApi{}.PowerOffServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2529,7 +2633,8 @@ func TestDedicatedNetworkEquipmentPowerOffServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedNetworkEquipmentApi{}.PowerOffServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedNetworkEquipmentApi{}.PowerOffServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2546,7 +2651,8 @@ func TestDedicatedNetworkEquipmentPowerOffServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedNetworkEquipmentApi{}.PowerOffServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedNetworkEquipmentApi{}.PowerOffServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2563,7 +2669,8 @@ func TestDedicatedNetworkEquipmentPowerOffServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedNetworkEquipmentApi{}.PowerOffServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedNetworkEquipmentApi{}.PowerOffServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2580,7 +2687,8 @@ func TestDedicatedNetworkEquipmentPowerOffServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedNetworkEquipmentApi{}.PowerOffServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedNetworkEquipmentApi{}.PowerOffServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2600,7 +2708,8 @@ func TestDedicatedNetworkEquipmentPowerOnServer(t *testing.T) {
 	})
 	defer teardown()
 
-	err := DedicatedNetworkEquipmentApi{}.PowerOnServer("server id")
+	ctx := context.Background()
+	err := DedicatedNetworkEquipmentApi{}.PowerOnServer(ctx, "server id")
 	assert := assert.New(t)
 	assert.Nil(err)
 }
@@ -2616,7 +2725,8 @@ func TestDedicatedNetworkEquipmentPowerOnServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedNetworkEquipmentApi{}.PowerOnServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedNetworkEquipmentApi{}.PowerOnServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2633,7 +2743,8 @@ func TestDedicatedNetworkEquipmentPowerOnServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedNetworkEquipmentApi{}.PowerOnServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedNetworkEquipmentApi{}.PowerOnServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2650,7 +2761,8 @@ func TestDedicatedNetworkEquipmentPowerOnServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedNetworkEquipmentApi{}.PowerOnServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedNetworkEquipmentApi{}.PowerOnServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2667,7 +2779,8 @@ func TestDedicatedNetworkEquipmentPowerOnServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedNetworkEquipmentApi{}.PowerOnServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedNetworkEquipmentApi{}.PowerOnServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2684,7 +2797,8 @@ func TestDedicatedNetworkEquipmentPowerOnServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedNetworkEquipmentApi{}.PowerOnServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedNetworkEquipmentApi{}.PowerOnServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2711,7 +2825,8 @@ func TestDedicatedNetworkEquipmentGetPowerStatus(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := DedicatedNetworkEquipmentApi{}.GetPowerStatus("server-id")
+	ctx := context.Background()
+	resp, err := DedicatedNetworkEquipmentApi{}.GetPowerStatus(ctx, "server-id")
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -2730,7 +2845,8 @@ func TestDedicatedNetworkEquipmentGetPowerStatusServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.GetPowerStatus("server-id")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.GetPowerStatus(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2747,7 +2863,8 @@ func TestDedicatedNetworkEquipmentGetPowerStatusServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.GetPowerStatus("server-id")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.GetPowerStatus(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2764,7 +2881,8 @@ func TestDedicatedNetworkEquipmentGetPowerStatusServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.GetPowerStatus("server-id")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.GetPowerStatus(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2781,7 +2899,8 @@ func TestDedicatedNetworkEquipmentGetPowerStatusServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.GetPowerStatus("server-id")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.GetPowerStatus(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2798,7 +2917,8 @@ func TestDedicatedNetworkEquipmentGetPowerStatusServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedNetworkEquipmentApi{}.GetPowerStatus("server-id")
+				ctx := context.Background()
+				return DedicatedNetworkEquipmentApi{}.GetPowerStatus(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",

--- a/dedicated_rack.go
+++ b/dedicated_rack.go
@@ -1,6 +1,7 @@
 package leaseweb
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -35,7 +36,7 @@ func (dra DedicatedRackApi) getPath(endpoint string) string {
 	return "/bareMetals/" + DEDICATED_RACK_API_VERSION + endpoint
 }
 
-func (dra DedicatedRackApi) List(args ...interface{}) (*DedicatedRacks, error) {
+func (dra DedicatedRackApi) List(ctx context.Context, args ...interface{}) (*DedicatedRacks, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -52,28 +53,28 @@ func (dra DedicatedRackApi) List(args ...interface{}) (*DedicatedRacks, error) {
 
 	path := dra.getPath("/privateRacks?" + v.Encode())
 	result := &DedicatedRacks{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dra DedicatedRackApi) Get(privateRackId string) (*DedicatedRack, error) {
+func (dra DedicatedRackApi) Get(ctx context.Context, privateRackId string) (*DedicatedRack, error) {
 	path := dra.getPath("/privateRacks/" + privateRackId)
 	result := &DedicatedRack{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dra DedicatedRackApi) Update(privateRackId, reference string) error {
+func (dra DedicatedRackApi) Update(ctx context.Context, privateRackId, reference string) error {
 	payload := map[string]string{"reference": reference}
 	path := dra.getPath("/privateRacks/" + privateRackId)
-	return doRequest(http.MethodPut, path, nil, payload)
+	return doRequest(ctx, http.MethodPut, path, nil, payload)
 }
 
-func (dra DedicatedRackApi) ListNullRoutes(privateRackId string, args ...interface{}) (*NullRoutes, error) {
+func (dra DedicatedRackApi) ListNullRoutes(ctx context.Context, privateRackId string, args ...interface{}) (*NullRoutes, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -84,13 +85,13 @@ func (dra DedicatedRackApi) ListNullRoutes(privateRackId string, args ...interfa
 
 	path := dra.getPath("/privateRacks/" + privateRackId + "/nullRouteHistory?" + v.Encode())
 	result := &NullRoutes{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dra DedicatedRackApi) ListIps(privateRackId string, args ...interface{}) (*Ips, error) {
+func (dra DedicatedRackApi) ListIps(ctx context.Context, privateRackId string, args ...interface{}) (*Ips, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -113,49 +114,49 @@ func (dra DedicatedRackApi) ListIps(privateRackId string, args ...interface{}) (
 
 	path := dra.getPath("/privateRacks/" + privateRackId + "/ips" + v.Encode())
 	result := &Ips{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dra DedicatedRackApi) GetIp(privateRackId, ip string) (*Ip, error) {
+func (dra DedicatedRackApi) GetIp(ctx context.Context, privateRackId, ip string) (*Ip, error) {
 	path := dra.getPath("/privateRacks/" + privateRackId + "/ips/" + ip)
 	result := &Ip{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dra DedicatedRackApi) UpdateIp(privateRackId, ip string, payload map[string]string) (*Ip, error) {
+func (dra DedicatedRackApi) UpdateIp(ctx context.Context, privateRackId, ip string, payload map[string]string) (*Ip, error) {
 	path := dra.getPath("/privateRacks/" + privateRackId + "/ips/" + ip)
 	result := &Ip{}
-	if err := doRequest(http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dra DedicatedRackApi) NullRouteAnIp(privateRackId, ip string) (*Ip, error) {
+func (dra DedicatedRackApi) NullRouteAnIp(ctx context.Context, privateRackId, ip string) (*Ip, error) {
 	path := dra.getPath("/privateRacks/" + privateRackId + "/ips/" + ip + "/null")
 	result := &Ip{}
-	if err := doRequest(http.MethodPost, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dra DedicatedRackApi) RemoveNullRouteAnIp(privateRackId, ip string) (*Ip, error) {
+func (dra DedicatedRackApi) RemoveNullRouteAnIp(ctx context.Context, privateRackId, ip string) (*Ip, error) {
 	path := dra.getPath("/privateRacks/" + privateRackId + "/ips/" + ip + "/unnull")
 	result := &Ip{}
-	if err := doRequest(http.MethodPost, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dra DedicatedRackApi) ListCredentials(privateRackId string, args ...int) (*Credentials, error) {
+func (dra DedicatedRackApi) ListCredentials(ctx context.Context, privateRackId string, args ...int) (*Credentials, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -166,26 +167,26 @@ func (dra DedicatedRackApi) ListCredentials(privateRackId string, args ...int) (
 
 	result := &Credentials{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/credentials?" + v.Encode())
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dra DedicatedRackApi) CreateCredential(privateRackId, credentialType, username, password string) (*Credential, error) {
+func (dra DedicatedRackApi) CreateCredential(ctx context.Context, privateRackId, credentialType, username, password string) (*Credential, error) {
 	result := &Credential{}
 	payload := make(map[string]string)
 	payload["type"] = credentialType
 	payload["username"] = username
 	payload["password"] = password
 	path := dra.getPath("/privateRacks/" + privateRackId + "/credentials")
-	if err := doRequest(http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dra DedicatedRackApi) ListCredentialsByType(privateRackId, credentialType string, args ...int) (*Credentials, error) {
+func (dra DedicatedRackApi) ListCredentialsByType(ctx context.Context, privateRackId, credentialType string, args ...int) (*Credentials, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -196,37 +197,37 @@ func (dra DedicatedRackApi) ListCredentialsByType(privateRackId, credentialType 
 
 	result := &Credentials{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/credentials/" + credentialType + "?" + v.Encode())
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dra DedicatedRackApi) GetCredential(privateRackId, credentialType, username string) (*Credential, error) {
+func (dra DedicatedRackApi) GetCredential(ctx context.Context, privateRackId, credentialType, username string) (*Credential, error) {
 	result := &Credential{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/credentials/" + credentialType + "/" + username)
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dra DedicatedRackApi) DeleteCredential(privateRackId, credentialType, username string) error {
+func (dra DedicatedRackApi) DeleteCredential(ctx context.Context, privateRackId, credentialType, username string) error {
 	path := dra.getPath("/privateRacks/" + privateRackId + "/credentials/" + credentialType + "/" + username)
-	return doRequest(http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path)
 }
 
-func (dra DedicatedRackApi) UpdateCredential(privateRackId, credentialType, username, password string) (*Credential, error) {
+func (dra DedicatedRackApi) UpdateCredential(ctx context.Context, privateRackId, credentialType, username, password string) (*Credential, error) {
 	result := &Credential{}
 	payload := map[string]string{"password": password}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/credentials/" + credentialType + "/" + username)
-	if err := doRequest(http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dra DedicatedRackApi) GetDataTrafficMetrics(privateRackId string, args ...interface{}) (*DataTrafficMetricsV1, error) {
+func (dra DedicatedRackApi) GetDataTrafficMetrics(ctx context.Context, privateRackId string, args ...interface{}) (*DataTrafficMetricsV1, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("granularity", fmt.Sprint(args[0]))
@@ -243,13 +244,13 @@ func (dra DedicatedRackApi) GetDataTrafficMetrics(privateRackId string, args ...
 
 	path := dra.getPath("/privateRacks/" + privateRackId + "/metrics/datatraffic?" + v.Encode())
 	result := &DataTrafficMetricsV1{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dra DedicatedRackApi) GetBandWidthMetrics(privateRackId string, args ...interface{}) (*BandWidthMetrics, error) {
+func (dra DedicatedRackApi) GetBandWidthMetrics(ctx context.Context, privateRackId string, args ...interface{}) (*BandWidthMetrics, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("granularity", fmt.Sprint(args[0]))
@@ -266,30 +267,30 @@ func (dra DedicatedRackApi) GetBandWidthMetrics(privateRackId string, args ...in
 
 	path := dra.getPath("/privateRacks/" + privateRackId + "/metrics/bandwidth?" + v.Encode())
 	result := &BandWidthMetrics{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dra DedicatedRackApi) GetDdosNotificationSetting(privateRackId string) (*DdosNotificationSetting, error) {
+func (dra DedicatedRackApi) GetDdosNotificationSetting(ctx context.Context, privateRackId string) (*DdosNotificationSetting, error) {
 	result := &DdosNotificationSetting{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/ddos")
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dra DedicatedRackApi) UpdateDdosNotificationSetting(privateRackId string, payload map[string]string) error {
+func (dra DedicatedRackApi) UpdateDdosNotificationSetting(ctx context.Context, privateRackId string, payload map[string]string) error {
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/ddos")
-	if err := doRequest(http.MethodPut, path, nil, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, nil, payload); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (dra DedicatedRackApi) ListBandWidthNotificationSettings(privateRackId string, args ...int) (*BandWidthNotificationSettings, error) {
+func (dra DedicatedRackApi) ListBandWidthNotificationSettings(ctx context.Context, privateRackId string, args ...int) (*BandWidthNotificationSettings, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -300,13 +301,13 @@ func (dra DedicatedRackApi) ListBandWidthNotificationSettings(privateRackId stri
 
 	result := &BandWidthNotificationSettings{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/bandwidth?" + v.Encode())
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dra DedicatedRackApi) CreateBandWidthNotificationSetting(privateRackId, frequency, threshold, unit string) (*NotificationSetting, error) {
+func (dra DedicatedRackApi) CreateBandWidthNotificationSetting(ctx context.Context, privateRackId, frequency, threshold, unit string) (*NotificationSetting, error) {
 	payload := map[string]string{
 		"frequency": frequency,
 		"threshold": threshold,
@@ -314,36 +315,36 @@ func (dra DedicatedRackApi) CreateBandWidthNotificationSetting(privateRackId, fr
 	}
 	result := &NotificationSetting{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/bandwidth")
-	if err := doRequest(http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dra DedicatedRackApi) DeleteBandWidthNotificationSetting(privateRackId, notificationId string) error {
+func (dra DedicatedRackApi) DeleteBandWidthNotificationSetting(ctx context.Context, privateRackId, notificationId string) error {
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/bandwidth/" + notificationId)
-	return doRequest(http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path)
 }
 
-func (dra DedicatedRackApi) GetBandWidthNotificationSetting(privateRackId, notificationId string) (*NotificationSetting, error) {
+func (dra DedicatedRackApi) GetBandWidthNotificationSetting(ctx context.Context, privateRackId, notificationId string) (*NotificationSetting, error) {
 	result := &NotificationSetting{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/bandwidth/" + notificationId)
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dra DedicatedRackApi) UpdateBandWidthNotificationSetting(privateRackId, notificationSettingId string, payload map[string]string) (*NotificationSetting, error) {
+func (dra DedicatedRackApi) UpdateBandWidthNotificationSetting(ctx context.Context, privateRackId, notificationSettingId string, payload map[string]string) (*NotificationSetting, error) {
 	result := &NotificationSetting{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/bandwidth/" + notificationSettingId)
-	if err := doRequest(http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dra DedicatedRackApi) ListDataTrafficNotificationSettings(privateRackId string, args ...int) (*DataTrafficNotificationSettings, error) {
+func (dra DedicatedRackApi) ListDataTrafficNotificationSettings(ctx context.Context, privateRackId string, args ...int) (*DataTrafficNotificationSettings, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -354,13 +355,13 @@ func (dra DedicatedRackApi) ListDataTrafficNotificationSettings(privateRackId st
 
 	result := &DataTrafficNotificationSettings{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/datatraffic?" + v.Encode())
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dra DedicatedRackApi) CreateDataTrafficNotificationSetting(privateRackId, frequency, threshold, unit string) (*NotificationSetting, error) {
+func (dra DedicatedRackApi) CreateDataTrafficNotificationSetting(ctx context.Context, privateRackId, frequency, threshold, unit string) (*NotificationSetting, error) {
 	payload := map[string]string{
 		"frequency": frequency,
 		"threshold": threshold,
@@ -368,30 +369,30 @@ func (dra DedicatedRackApi) CreateDataTrafficNotificationSetting(privateRackId, 
 	}
 	result := &NotificationSetting{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/datatraffic")
-	if err := doRequest(http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dra DedicatedRackApi) DeleteDataTrafficNotificationSetting(privateRackId, notificationId string) error {
+func (dra DedicatedRackApi) DeleteDataTrafficNotificationSetting(ctx context.Context, privateRackId, notificationId string) error {
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/datatraffic/" + notificationId)
-	return doRequest(http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path)
 }
 
-func (dra DedicatedRackApi) GetDataTrafficNotificationSetting(privateRackId, notificationId string) (*NotificationSetting, error) {
+func (dra DedicatedRackApi) GetDataTrafficNotificationSetting(ctx context.Context, privateRackId, notificationId string) (*NotificationSetting, error) {
 	result := &NotificationSetting{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/datatraffic/" + notificationId)
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dra DedicatedRackApi) UpdateDataTrafficNotificationSetting(privateRackId, notificationSettingId string, payload map[string]string) (*NotificationSetting, error) {
+func (dra DedicatedRackApi) UpdateDataTrafficNotificationSetting(ctx context.Context, privateRackId, notificationSettingId string, payload map[string]string) (*NotificationSetting, error) {
 	result := &NotificationSetting{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/datatraffic/" + notificationSettingId)
-	if err := doRequest(http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
 		return result, err
 	}
 	return result, nil

--- a/dedicated_rack_test.go
+++ b/dedicated_rack_test.go
@@ -1,6 +1,7 @@
 package leaseweb
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -82,7 +83,8 @@ func TestDedicatedRackList(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedRackApi{}.List()
+	ctx := context.Background()
+	response, err := DedicatedRackApi{}.List(ctx)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 2)
@@ -128,7 +130,8 @@ func TestDedicatedRackListBeEmpty(t *testing.T) {
 		fmt.Fprintf(w, `{"_metadata":{"limit": 10, "offset": 0, "totalCount": 0}, "privateRacks": []}`)
 	})
 	defer teardown()
-	response, err := DedicatedRackApi{}.List()
+	ctx := context.Background()
+	response, err := DedicatedRackApi{}.List(ctx)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 0)
@@ -182,7 +185,8 @@ func TestDedicatedRackListPaginateAndFilter(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedRackApi{}.List(1)
+	ctx := context.Background()
+	response, err := DedicatedRackApi{}.List(ctx, 1)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 11)
@@ -217,7 +221,8 @@ func TestDedicatedRackListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.List()
+				ctx := context.Background()
+				return DedicatedRackApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -234,7 +239,8 @@ func TestDedicatedRackListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.List()
+				ctx := context.Background()
+				return DedicatedRackApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -251,7 +257,8 @@ func TestDedicatedRackListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.List()
+				ctx := context.Background()
+				return DedicatedRackApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -268,7 +275,8 @@ func TestDedicatedRackListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.List()
+				ctx := context.Background()
+				return DedicatedRackApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -338,7 +346,8 @@ func TestDedicatedRackGet(t *testing.T) {
 	})
 	defer teardown()
 
-	Rack, err := DedicatedRackApi{}.Get("2893829")
+	ctx := context.Background()
+	Rack, err := DedicatedRackApi{}.Get(ctx, "2893829")
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -383,7 +392,8 @@ func TestDedicatedRackGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.Get("2893829")
+				ctx := context.Background()
+				return DedicatedRackApi{}.Get(ctx, "2893829")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -400,7 +410,8 @@ func TestDedicatedRackGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.Get("2893829")
+				ctx := context.Background()
+				return DedicatedRackApi{}.Get(ctx, "2893829")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -417,7 +428,8 @@ func TestDedicatedRackGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.Get("2893829")
+				ctx := context.Background()
+				return DedicatedRackApi{}.Get(ctx, "2893829")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -434,7 +446,8 @@ func TestDedicatedRackGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.Get("2893829")
+				ctx := context.Background()
+				return DedicatedRackApi{}.Get(ctx, "2893829")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -454,7 +467,8 @@ func TestDedicatedRackUpdate(t *testing.T) {
 	})
 	defer teardown()
 
-	err := DedicatedRackApi{}.Update("2893829", "new reference")
+	ctx := context.Background()
+	err := DedicatedRackApi{}.Update(ctx, "2893829", "new reference")
 	assert := assert.New(t)
 	assert.Nil(err)
 }
@@ -470,7 +484,8 @@ func TestDedicatedRackUpdateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedRackApi{}.Update("2893829", "new reference")
+				ctx := context.Background()
+				return nil, DedicatedRackApi{}.Update(ctx, "2893829", "new reference")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -487,7 +502,8 @@ func TestDedicatedRackUpdateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedRackApi{}.Update("2893829", "new reference")
+				ctx := context.Background()
+				return nil, DedicatedRackApi{}.Update(ctx, "2893829", "new reference")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -504,7 +520,8 @@ func TestDedicatedRackUpdateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedRackApi{}.Update("2893829", "new reference")
+				ctx := context.Background()
+				return nil, DedicatedRackApi{}.Update(ctx, "2893829", "new reference")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -521,7 +538,8 @@ func TestDedicatedRackUpdateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedRackApi{}.Update("2893829", "new reference")
+				ctx := context.Background()
+				return nil, DedicatedRackApi{}.Update(ctx, "2893829", "new reference")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -557,7 +575,8 @@ func TestDedicatedRackListNullRoutes(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedRackApi{}.ListNullRoutes("123456")
+	ctx := context.Background()
+	response, err := DedicatedRackApi{}.ListNullRoutes(ctx, "123456")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 1)
@@ -598,7 +617,8 @@ func TestDedicatedRackListNullRoutesPaginateAndFilter(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedRackApi{}.ListNullRoutes("123456", 1)
+	ctx := context.Background()
+	response, err := DedicatedRackApi{}.ListNullRoutes(ctx, "123456", 1)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 11)
@@ -626,7 +646,8 @@ func TestDedicatedRackListNullRoutesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.ListNullRoutes("123456")
+				ctx := context.Background()
+				return DedicatedRackApi{}.ListNullRoutes(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -643,7 +664,8 @@ func TestDedicatedRackListNullRoutesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.ListNullRoutes("123456")
+				ctx := context.Background()
+				return DedicatedRackApi{}.ListNullRoutes(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -660,7 +682,8 @@ func TestDedicatedRackListNullRoutesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.ListNullRoutes("123456")
+				ctx := context.Background()
+				return DedicatedRackApi{}.ListNullRoutes(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -677,7 +700,8 @@ func TestDedicatedRackListNullRoutesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.ListNullRoutes("123456")
+				ctx := context.Background()
+				return DedicatedRackApi{}.ListNullRoutes(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -733,7 +757,8 @@ func TestDedicatedRackListIps(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedRackApi{}.ListIps("123456")
+	ctx := context.Background()
+	response, err := DedicatedRackApi{}.ListIps(ctx, "123456")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 2)
@@ -796,7 +821,8 @@ func TestDedicatedRackListIpsPaginateAndFilter(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedRackApi{}.ListIps("123456", 1)
+	ctx := context.Background()
+	response, err := DedicatedRackApi{}.ListIps(ctx, "123456", 1)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 11)
@@ -828,7 +854,8 @@ func TestDedicatedRackListIpsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.ListIps("123456")
+				ctx := context.Background()
+				return DedicatedRackApi{}.ListIps(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -845,7 +872,8 @@ func TestDedicatedRackListIpsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.ListIps("123456")
+				ctx := context.Background()
+				return DedicatedRackApi{}.ListIps(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -862,7 +890,8 @@ func TestDedicatedRackListIpsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.ListIps("123456")
+				ctx := context.Background()
+				return DedicatedRackApi{}.ListIps(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -879,7 +908,8 @@ func TestDedicatedRackListIpsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.ListIps("123456")
+				ctx := context.Background()
+				return DedicatedRackApi{}.ListIps(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -912,7 +942,8 @@ func TestDedicatedRackGetIps(t *testing.T) {
 	})
 	defer teardown()
 
-	Ip, err := DedicatedRackApi{}.GetIp("123456", "12.123.123.1")
+	ctx := context.Background()
+	Ip, err := DedicatedRackApi{}.GetIp(ctx, "123456", "12.123.123.1")
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -939,7 +970,8 @@ func TestDedicatedRackGetIpsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetIp("123456", "12.123.123.1")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetIp(ctx, "123456", "12.123.123.1")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -956,7 +988,8 @@ func TestDedicatedRackGetIpsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetIp("123456", "12.123.123.1")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetIp(ctx, "123456", "12.123.123.1")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -973,7 +1006,8 @@ func TestDedicatedRackGetIpsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetIp("123456", "12.123.123.1")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetIp(ctx, "123456", "12.123.123.1")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -990,7 +1024,8 @@ func TestDedicatedRackGetIpsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetIp("123456", "12.123.123.1")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetIp(ctx, "123456", "12.123.123.1")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1023,7 +1058,8 @@ func TestDedicatedRackUpdateIp(t *testing.T) {
 	})
 	defer teardown()
 
-	Ip, err := DedicatedRackApi{}.UpdateIp("123456", "12.123.123.1", map[string]string{"reverseLookup": "domain.example.com", "detectionProfile": "ADVANCED_LOW_UDP"})
+	ctx := context.Background()
+	Ip, err := DedicatedRackApi{}.UpdateIp(ctx, "123456", "12.123.123.1", map[string]string{"reverseLookup": "domain.example.com", "detectionProfile": "ADVANCED_LOW_UDP"})
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -1050,7 +1086,8 @@ func TestDedicatedRackUpdateIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.UpdateIp("123456", "12.123.123.1", map[string]string{"reverseLookup": "domain.example.com", "detectionProfile": "ADVANCED_LOW_UDP"})
+				ctx := context.Background()
+				return DedicatedRackApi{}.UpdateIp(ctx, "123456", "12.123.123.1", map[string]string{"reverseLookup": "domain.example.com", "detectionProfile": "ADVANCED_LOW_UDP"})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1067,7 +1104,8 @@ func TestDedicatedRackUpdateIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.UpdateIp("123456", "12.123.123.1", map[string]string{"reverseLookup": "domain.example.com", "detectionProfile": "ADVANCED_LOW_UDP"})
+				ctx := context.Background()
+				return DedicatedRackApi{}.UpdateIp(ctx, "123456", "12.123.123.1", map[string]string{"reverseLookup": "domain.example.com", "detectionProfile": "ADVANCED_LOW_UDP"})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1084,7 +1122,8 @@ func TestDedicatedRackUpdateIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.UpdateIp("123456", "12.123.123.1", map[string]string{"reverseLookup": "domain.example.com", "detectionProfile": "ADVANCED_LOW_UDP"})
+				ctx := context.Background()
+				return DedicatedRackApi{}.UpdateIp(ctx, "123456", "12.123.123.1", map[string]string{"reverseLookup": "domain.example.com", "detectionProfile": "ADVANCED_LOW_UDP"})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1101,7 +1140,8 @@ func TestDedicatedRackUpdateIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.UpdateIp("123456", "12.123.123.1", map[string]string{"reverseLookup": "domain.example.com", "detectionProfile": "ADVANCED_LOW_UDP"})
+				ctx := context.Background()
+				return DedicatedRackApi{}.UpdateIp(ctx, "123456", "12.123.123.1", map[string]string{"reverseLookup": "domain.example.com", "detectionProfile": "ADVANCED_LOW_UDP"})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1134,7 +1174,8 @@ func TestDedicatedRackNullRouteAnIp(t *testing.T) {
 	})
 	defer teardown()
 
-	Ip, err := DedicatedRackApi{}.NullRouteAnIp("123456", "12.123.123.1")
+	ctx := context.Background()
+	Ip, err := DedicatedRackApi{}.NullRouteAnIp(ctx, "123456", "12.123.123.1")
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -1161,7 +1202,8 @@ func TestDedicatedRackNullRouteAnIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.NullRouteAnIp("123456", "12.123.123.1")
+				ctx := context.Background()
+				return DedicatedRackApi{}.NullRouteAnIp(ctx, "123456", "12.123.123.1")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1178,7 +1220,8 @@ func TestDedicatedRackNullRouteAnIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.NullRouteAnIp("123456", "12.123.123.1")
+				ctx := context.Background()
+				return DedicatedRackApi{}.NullRouteAnIp(ctx, "123456", "12.123.123.1")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1195,7 +1238,8 @@ func TestDedicatedRackNullRouteAnIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.NullRouteAnIp("123456", "12.123.123.1")
+				ctx := context.Background()
+				return DedicatedRackApi{}.NullRouteAnIp(ctx, "123456", "12.123.123.1")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1212,7 +1256,8 @@ func TestDedicatedRackNullRouteAnIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.NullRouteAnIp("123456", "12.123.123.1")
+				ctx := context.Background()
+				return DedicatedRackApi{}.NullRouteAnIp(ctx, "123456", "12.123.123.1")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1245,7 +1290,8 @@ func TestDedicatedRackRemoveNullRouteAnIp(t *testing.T) {
 	})
 	defer teardown()
 
-	Ip, err := DedicatedRackApi{}.RemoveNullRouteAnIp("123456", "12.123.123.1")
+	ctx := context.Background()
+	Ip, err := DedicatedRackApi{}.RemoveNullRouteAnIp(ctx, "123456", "12.123.123.1")
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -1272,7 +1318,8 @@ func TestDedicatedRackRemoveNullRouteAnIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.RemoveNullRouteAnIp("123456", "12.123.123.1")
+				ctx := context.Background()
+				return DedicatedRackApi{}.RemoveNullRouteAnIp(ctx, "123456", "12.123.123.1")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1289,7 +1336,8 @@ func TestDedicatedRackRemoveNullRouteAnIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.RemoveNullRouteAnIp("123456", "12.123.123.1")
+				ctx := context.Background()
+				return DedicatedRackApi{}.RemoveNullRouteAnIp(ctx, "123456", "12.123.123.1")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1306,7 +1354,8 @@ func TestDedicatedRackRemoveNullRouteAnIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.RemoveNullRouteAnIp("123456", "12.123.123.1")
+				ctx := context.Background()
+				return DedicatedRackApi{}.RemoveNullRouteAnIp(ctx, "123456", "12.123.123.1")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1323,7 +1372,8 @@ func TestDedicatedRackRemoveNullRouteAnIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.RemoveNullRouteAnIp("123456", "12.123.123.1")
+				ctx := context.Background()
+				return DedicatedRackApi{}.RemoveNullRouteAnIp(ctx, "123456", "12.123.123.1")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1367,7 +1417,8 @@ func TestDedicatedRackListCredentials(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedRackApi{}.ListCredentials("99944")
+	ctx := context.Background()
+	response, err := DedicatedRackApi{}.ListCredentials(ctx, "99944")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 4)
@@ -1392,7 +1443,8 @@ func TestDedicatedRackListCredentialsBeEmpty(t *testing.T) {
 		fmt.Fprintf(w, `{"_metadata":{"limit": 10, "offset": 0, "totalCount": 0}, "credentials": []}`)
 	})
 	defer teardown()
-	response, err := DedicatedRackApi{}.ListCredentials("99944")
+	ctx := context.Background()
+	response, err := DedicatedRackApi{}.ListCredentials(ctx, "99944")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 0)
@@ -1421,7 +1473,8 @@ func TestDedicatedRackListCredentialsPaginate(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedRackApi{}.ListCredentials("99944")
+	ctx := context.Background()
+	response, err := DedicatedRackApi{}.ListCredentials(ctx, "99944")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 11)
@@ -1444,7 +1497,8 @@ func TestDedicatedRackListCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.ListCredentials("99944")
+				ctx := context.Background()
+				return DedicatedRackApi{}.ListCredentials(ctx, "99944")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1461,7 +1515,8 @@ func TestDedicatedRackListCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.ListCredentials("99944")
+				ctx := context.Background()
+				return DedicatedRackApi{}.ListCredentials(ctx, "99944")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1478,7 +1533,8 @@ func TestDedicatedRackListCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.ListCredentials("99944")
+				ctx := context.Background()
+				return DedicatedRackApi{}.ListCredentials(ctx, "99944")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1495,7 +1551,8 @@ func TestDedicatedRackListCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.ListCredentials("99944")
+				ctx := context.Background()
+				return DedicatedRackApi{}.ListCredentials(ctx, "99944")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1512,7 +1569,8 @@ func TestDedicatedRackListCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.ListCredentials("99944")
+				ctx := context.Background()
+				return DedicatedRackApi{}.ListCredentials(ctx, "99944")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1536,7 +1594,8 @@ func TestDedicatedRackCreateCredential(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := DedicatedRackApi{}.CreateCredential("12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
+	ctx := context.Background()
+	resp, err := DedicatedRackApi{}.CreateCredential(ctx, "12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -1556,7 +1615,8 @@ func TestDedicatedRackCreateCredentialServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.CreateCredential("12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
+				ctx := context.Background()
+				return DedicatedRackApi{}.CreateCredential(ctx, "12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1573,7 +1633,8 @@ func TestDedicatedRackCreateCredentialServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.CreateCredential("12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
+				ctx := context.Background()
+				return DedicatedRackApi{}.CreateCredential(ctx, "12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1590,7 +1651,8 @@ func TestDedicatedRackCreateCredentialServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.CreateCredential("12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
+				ctx := context.Background()
+				return DedicatedRackApi{}.CreateCredential(ctx, "12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1607,7 +1669,8 @@ func TestDedicatedRackCreateCredentialServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.CreateCredential("12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
+				ctx := context.Background()
+				return DedicatedRackApi{}.CreateCredential(ctx, "12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1624,7 +1687,8 @@ func TestDedicatedRackCreateCredentialServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.CreateCredential("12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
+				ctx := context.Background()
+				return DedicatedRackApi{}.CreateCredential(ctx, "12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1660,7 +1724,8 @@ func TestDedicatedRackListCredentialsByType(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedRackApi{}.ListCredentialsByType("99944", "REMOTE_MANAGEMENT")
+	ctx := context.Background()
+	response, err := DedicatedRackApi{}.ListCredentialsByType(ctx, "99944", "REMOTE_MANAGEMENT")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 2)
@@ -1681,7 +1746,8 @@ func TestDedicatedRackListCredentialsByTypeBeEmpty(t *testing.T) {
 		fmt.Fprintf(w, `{"_metadata":{"limit": 10, "offset": 0, "totalCount": 0}, "credentials": []}`)
 	})
 	defer teardown()
-	response, err := DedicatedRackApi{}.ListCredentialsByType("99944", "REMOTE_MANAGEMENT")
+	ctx := context.Background()
+	response, err := DedicatedRackApi{}.ListCredentialsByType(ctx, "99944", "REMOTE_MANAGEMENT")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 0)
@@ -1710,7 +1776,8 @@ func TestDedicatedRackListCredentialsByTypePaginate(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedRackApi{}.ListCredentialsByType("99944", "REMOTE_MANAGEMENT")
+	ctx := context.Background()
+	response, err := DedicatedRackApi{}.ListCredentialsByType(ctx, "99944", "REMOTE_MANAGEMENT")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 11)
@@ -1733,7 +1800,8 @@ func TestDedicatedRackListCredentialsByTypeServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.ListCredentialsByType("99944", "REMOTE_MANAGEMENT")
+				ctx := context.Background()
+				return DedicatedRackApi{}.ListCredentialsByType(ctx, "99944", "REMOTE_MANAGEMENT")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1750,7 +1818,8 @@ func TestDedicatedRackListCredentialsByTypeServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.ListCredentialsByType("99944", "REMOTE_MANAGEMENT")
+				ctx := context.Background()
+				return DedicatedRackApi{}.ListCredentialsByType(ctx, "99944", "REMOTE_MANAGEMENT")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1767,7 +1836,8 @@ func TestDedicatedRackListCredentialsByTypeServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.ListCredentialsByType("99944", "REMOTE_MANAGEMENT")
+				ctx := context.Background()
+				return DedicatedRackApi{}.ListCredentialsByType(ctx, "99944", "REMOTE_MANAGEMENT")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1784,7 +1854,8 @@ func TestDedicatedRackListCredentialsByTypeServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.ListCredentialsByType("99944", "REMOTE_MANAGEMENT")
+				ctx := context.Background()
+				return DedicatedRackApi{}.ListCredentialsByType(ctx, "99944", "REMOTE_MANAGEMENT")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1801,7 +1872,8 @@ func TestDedicatedRackListCredentialsByTypeServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.ListCredentialsByType("99944", "REMOTE_MANAGEMENT")
+				ctx := context.Background()
+				return DedicatedRackApi{}.ListCredentialsByType(ctx, "99944", "REMOTE_MANAGEMENT")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1825,7 +1897,8 @@ func TestDedicatedRackGetCredentials(t *testing.T) {
 	})
 	defer teardown()
 
-	Credential, err := DedicatedRackApi{}.GetCredential("12345", "OPERATING_SYSTEM", "root")
+	ctx := context.Background()
+	Credential, err := DedicatedRackApi{}.GetCredential(ctx, "12345", "OPERATING_SYSTEM", "root")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(Credential.Password, "mys3cr3tp@ssw0rd")
@@ -1844,7 +1917,8 @@ func TestDedicatedRackGetCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetCredential("12345", "OPERATING_SYSTEM", "root")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetCredential(ctx, "12345", "OPERATING_SYSTEM", "root")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1861,7 +1935,8 @@ func TestDedicatedRackGetCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetCredential("12345", "OPERATING_SYSTEM", "root")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetCredential(ctx, "12345", "OPERATING_SYSTEM", "root")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1878,7 +1953,8 @@ func TestDedicatedRackGetCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetCredential("12345", "OPERATING_SYSTEM", "root")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetCredential(ctx, "12345", "OPERATING_SYSTEM", "root")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1895,7 +1971,8 @@ func TestDedicatedRackGetCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetCredential("12345", "OPERATING_SYSTEM", "root")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetCredential(ctx, "12345", "OPERATING_SYSTEM", "root")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1912,7 +1989,8 @@ func TestDedicatedRackGetCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetCredential("12345", "OPERATING_SYSTEM", "root")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetCredential(ctx, "12345", "OPERATING_SYSTEM", "root")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1932,7 +2010,8 @@ func TestDedicatedRackDeleteCredentials(t *testing.T) {
 	})
 	defer teardown()
 
-	err := DedicatedRackApi{}.DeleteCredential("12345", "OPERATING_SYSTEM", "admin")
+	ctx := context.Background()
+	err := DedicatedRackApi{}.DeleteCredential(ctx, "12345", "OPERATING_SYSTEM", "admin")
 	assert := assert.New(t)
 	assert.Nil(err)
 }
@@ -1948,7 +2027,8 @@ func TestDedicatedRackDeleteCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedRackApi{}.DeleteCredential("12345", "OPERATING_SYSTEM", "admin")
+				ctx := context.Background()
+				return nil, DedicatedRackApi{}.DeleteCredential(ctx, "12345", "OPERATING_SYSTEM", "admin")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1965,7 +2045,8 @@ func TestDedicatedRackDeleteCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedRackApi{}.DeleteCredential("12345", "OPERATING_SYSTEM", "admin")
+				ctx := context.Background()
+				return nil, DedicatedRackApi{}.DeleteCredential(ctx, "12345", "OPERATING_SYSTEM", "admin")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1982,7 +2063,8 @@ func TestDedicatedRackDeleteCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedRackApi{}.DeleteCredential("12345", "OPERATING_SYSTEM", "admin")
+				ctx := context.Background()
+				return nil, DedicatedRackApi{}.DeleteCredential(ctx, "12345", "OPERATING_SYSTEM", "admin")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1999,7 +2081,8 @@ func TestDedicatedRackDeleteCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedRackApi{}.DeleteCredential("12345", "OPERATING_SYSTEM", "admin")
+				ctx := context.Background()
+				return nil, DedicatedRackApi{}.DeleteCredential(ctx, "12345", "OPERATING_SYSTEM", "admin")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2016,7 +2099,8 @@ func TestDedicatedRackDeleteCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedRackApi{}.DeleteCredential("12345", "OPERATING_SYSTEM", "admin")
+				ctx := context.Background()
+				return nil, DedicatedRackApi{}.DeleteCredential(ctx, "12345", "OPERATING_SYSTEM", "admin")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2040,7 +2124,8 @@ func TestDedicatedRackUpdateCredentials(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := DedicatedRackApi{}.UpdateCredential("12345", "OPERATING_SYSTEM", "admin", "new password")
+	ctx := context.Background()
+	resp, err := DedicatedRackApi{}.UpdateCredential(ctx, "12345", "OPERATING_SYSTEM", "admin", "new password")
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -2060,7 +2145,8 @@ func TestDedicatedRackUpdateCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.UpdateCredential("12345", "OPERATING_SYSTEM", "admin", "new password")
+				ctx := context.Background()
+				return DedicatedRackApi{}.UpdateCredential(ctx, "12345", "OPERATING_SYSTEM", "admin", "new password")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2077,7 +2163,8 @@ func TestDedicatedRackUpdateCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.UpdateCredential("12345", "OPERATING_SYSTEM", "admin", "new password")
+				ctx := context.Background()
+				return DedicatedRackApi{}.UpdateCredential(ctx, "12345", "OPERATING_SYSTEM", "admin", "new password")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2094,7 +2181,8 @@ func TestDedicatedRackUpdateCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.UpdateCredential("12345", "OPERATING_SYSTEM", "admin", "new password")
+				ctx := context.Background()
+				return DedicatedRackApi{}.UpdateCredential(ctx, "12345", "OPERATING_SYSTEM", "admin", "new password")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2111,7 +2199,8 @@ func TestDedicatedRackUpdateCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.UpdateCredential("12345", "OPERATING_SYSTEM", "admin", "new password")
+				ctx := context.Background()
+				return DedicatedRackApi{}.UpdateCredential(ctx, "12345", "OPERATING_SYSTEM", "admin", "new password")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2128,7 +2217,8 @@ func TestDedicatedRackUpdateCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.UpdateCredential("12345", "OPERATING_SYSTEM", "admin", "new password")
+				ctx := context.Background()
+				return DedicatedRackApi{}.UpdateCredential(ctx, "12345", "OPERATING_SYSTEM", "admin", "new password")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2183,7 +2273,8 @@ func TestDedicatedRackGetBandWidthMetrics(t *testing.T) {
 	})
 	defer teardown()
 
-	Metric, err := DedicatedRackApi{}.GetBandWidthMetrics("99944", "HOUR", "AVG", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+	ctx := context.Background()
+	Metric, err := DedicatedRackApi{}.GetBandWidthMetrics(ctx, "99944", "HOUR", "AVG", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(Metric.Metadata.Aggregation, "AVG")
@@ -2214,7 +2305,8 @@ func TestDedicatedRackGetBandWidthMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetBandWidthMetrics("99944", "HOUR", "AVG", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetBandWidthMetrics(ctx, "99944", "HOUR", "AVG", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2231,7 +2323,8 @@ func TestDedicatedRackGetBandWidthMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetBandWidthMetrics("99944", "HOUR", "AVG", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetBandWidthMetrics(ctx, "99944", "HOUR", "AVG", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2248,7 +2341,8 @@ func TestDedicatedRackGetBandWidthMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetBandWidthMetrics("99944", "HOUR", "AVG", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetBandWidthMetrics(ctx, "99944", "HOUR", "AVG", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2265,7 +2359,8 @@ func TestDedicatedRackGetBandWidthMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetBandWidthMetrics("99944", "HOUR", "AVG", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetBandWidthMetrics(ctx, "99944", "HOUR", "AVG", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2282,7 +2377,8 @@ func TestDedicatedRackGetBandWidthMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetBandWidthMetrics("99944", "HOUR", "AVG", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetBandWidthMetrics(ctx, "99944", "HOUR", "AVG", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2337,7 +2433,8 @@ func TestDedicatedRackGetDataTrafficMetrics(t *testing.T) {
 	})
 	defer teardown()
 
-	Metric, err := DedicatedRackApi{}.GetDataTrafficMetrics("99944", "HOUR", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+	ctx := context.Background()
+	Metric, err := DedicatedRackApi{}.GetDataTrafficMetrics(ctx, "99944", "HOUR", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(Metric.Metadata.Aggregation, "SUM")
@@ -2368,7 +2465,8 @@ func TestDedicatedRackGetDataTrafficMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetDataTrafficMetrics("99944", "HOUR", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetDataTrafficMetrics(ctx, "99944", "HOUR", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2385,7 +2483,8 @@ func TestDedicatedRackGetDataTrafficMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetDataTrafficMetrics("99944", "HOUR", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetDataTrafficMetrics(ctx, "99944", "HOUR", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2402,7 +2501,8 @@ func TestDedicatedRackGetDataTrafficMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetDataTrafficMetrics("99944", "HOUR", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetDataTrafficMetrics(ctx, "99944", "HOUR", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2419,7 +2519,8 @@ func TestDedicatedRackGetDataTrafficMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetDataTrafficMetrics("99944", "HOUR", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetDataTrafficMetrics(ctx, "99944", "HOUR", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2436,7 +2537,8 @@ func TestDedicatedRackGetDataTrafficMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetDataTrafficMetrics("99944", "HOUR", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetDataTrafficMetrics(ctx, "99944", "HOUR", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2459,7 +2561,8 @@ func TestDedicatedRackGetDdosNotificationSetting(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := DedicatedRackApi{}.GetDdosNotificationSetting("server-id")
+	ctx := context.Background()
+	resp, err := DedicatedRackApi{}.GetDdosNotificationSetting(ctx, "server-id")
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -2478,7 +2581,8 @@ func TestDedicatedRackGetDdosNotificationSettingServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetDdosNotificationSetting("server-id")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetDdosNotificationSetting(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2495,7 +2599,8 @@ func TestDedicatedRackGetDdosNotificationSettingServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetDdosNotificationSetting("server-id")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetDdosNotificationSetting(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2512,7 +2617,8 @@ func TestDedicatedRackGetDdosNotificationSettingServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetDdosNotificationSetting("server-id")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetDdosNotificationSetting(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2529,7 +2635,8 @@ func TestDedicatedRackGetDdosNotificationSettingServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetDdosNotificationSetting("server-id")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetDdosNotificationSetting(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2546,7 +2653,8 @@ func TestDedicatedRackGetDdosNotificationSettingServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetDdosNotificationSetting("server-id")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetDdosNotificationSetting(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2566,7 +2674,8 @@ func TestDedicatedRackUpdateDdosNotificationSetting(t *testing.T) {
 	})
 	defer teardown()
 
-	err := DedicatedRackApi{}.UpdateDdosNotificationSetting("server id", map[string]string{"nulling": "DISABLED", "scrubbing": "ENABLED"})
+	ctx := context.Background()
+	err := DedicatedRackApi{}.UpdateDdosNotificationSetting(ctx, "server id", map[string]string{"nulling": "DISABLED", "scrubbing": "ENABLED"})
 	assert := assert.New(t)
 	assert.Nil(err)
 }
@@ -2582,7 +2691,8 @@ func TestDedicatedRackUpdateDdosNotificationSettingServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedRackApi{}.UpdateDdosNotificationSetting("server id", map[string]string{"nulling": "DISABLED", "scrubbing": "ENABLED"})
+				ctx := context.Background()
+				return nil, DedicatedRackApi{}.UpdateDdosNotificationSetting(ctx, "server id", map[string]string{"nulling": "DISABLED", "scrubbing": "ENABLED"})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2599,7 +2709,8 @@ func TestDedicatedRackUpdateDdosNotificationSettingServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedRackApi{}.UpdateDdosNotificationSetting("server id", map[string]string{"nulling": "DISABLED", "scrubbing": "ENABLED"})
+				ctx := context.Background()
+				return nil, DedicatedRackApi{}.UpdateDdosNotificationSetting(ctx, "server id", map[string]string{"nulling": "DISABLED", "scrubbing": "ENABLED"})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2616,7 +2727,8 @@ func TestDedicatedRackUpdateDdosNotificationSettingServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedRackApi{}.UpdateDdosNotificationSetting("server id", map[string]string{"nulling": "DISABLED", "scrubbing": "ENABLED"})
+				ctx := context.Background()
+				return nil, DedicatedRackApi{}.UpdateDdosNotificationSetting(ctx, "server id", map[string]string{"nulling": "DISABLED", "scrubbing": "ENABLED"})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2633,7 +2745,8 @@ func TestDedicatedRackUpdateDdosNotificationSettingServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedRackApi{}.UpdateDdosNotificationSetting("server id", map[string]string{"nulling": "DISABLED", "scrubbing": "ENABLED"})
+				ctx := context.Background()
+				return nil, DedicatedRackApi{}.UpdateDdosNotificationSetting(ctx, "server id", map[string]string{"nulling": "DISABLED", "scrubbing": "ENABLED"})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2650,7 +2763,8 @@ func TestDedicatedRackUpdateDdosNotificationSettingServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedRackApi{}.UpdateDdosNotificationSetting("server id", map[string]string{"nulling": "DISABLED", "scrubbing": "ENABLED"})
+				ctx := context.Background()
+				return nil, DedicatedRackApi{}.UpdateDdosNotificationSetting(ctx, "server id", map[string]string{"nulling": "DISABLED", "scrubbing": "ENABLED"})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2706,7 +2820,8 @@ func TestDedicatedRackListDataTrafficNotificationSettings(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := DedicatedRackApi{}.ListDataTrafficNotificationSettings("server-id")
+	ctx := context.Background()
+	resp, err := DedicatedRackApi{}.ListDataTrafficNotificationSettings(ctx, "server-id")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(resp.Metadata.TotalCount, 2)
@@ -2763,7 +2878,8 @@ func TestDedicatedRackListDataTrafficNotificationSettingsPaginate(t *testing.T) 
 	})
 	defer teardown()
 
-	resp, err := DedicatedRackApi{}.ListDataTrafficNotificationSettings("server-id", 1)
+	ctx := context.Background()
+	resp, err := DedicatedRackApi{}.ListDataTrafficNotificationSettings(ctx, "server-id", 1)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(resp.Metadata.TotalCount, 11)
@@ -2792,7 +2908,8 @@ func TestDedicatedRackListDataTrafficNotificationSettingsServerErrors(t *testing
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.ListDataTrafficNotificationSettings("server-id")
+				ctx := context.Background()
+				return DedicatedRackApi{}.ListDataTrafficNotificationSettings(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2809,7 +2926,8 @@ func TestDedicatedRackListDataTrafficNotificationSettingsServerErrors(t *testing
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.ListDataTrafficNotificationSettings("server-id")
+				ctx := context.Background()
+				return DedicatedRackApi{}.ListDataTrafficNotificationSettings(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2826,7 +2944,8 @@ func TestDedicatedRackListDataTrafficNotificationSettingsServerErrors(t *testing
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.ListDataTrafficNotificationSettings("server-id")
+				ctx := context.Background()
+				return DedicatedRackApi{}.ListDataTrafficNotificationSettings(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2843,7 +2962,8 @@ func TestDedicatedRackListDataTrafficNotificationSettingsServerErrors(t *testing
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.ListDataTrafficNotificationSettings("server-id")
+				ctx := context.Background()
+				return DedicatedRackApi{}.ListDataTrafficNotificationSettings(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2860,7 +2980,8 @@ func TestDedicatedRackListDataTrafficNotificationSettingsServerErrors(t *testing
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.ListDataTrafficNotificationSettings("server-id")
+				ctx := context.Background()
+				return DedicatedRackApi{}.ListDataTrafficNotificationSettings(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2893,7 +3014,8 @@ func TestDedicatedRackCreateDataTrafficNotificationSetting(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := DedicatedRackApi{}.CreateDataTrafficNotificationSetting("server-id", "WEEKLY", "1", "GB")
+	ctx := context.Background()
+	resp, err := DedicatedRackApi{}.CreateDataTrafficNotificationSetting(ctx, "server-id", "WEEKLY", "1", "GB")
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -2918,7 +3040,8 @@ func TestDedicatedRackCreateDataTrafficNotificationSettingServerErrors(t *testin
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.CreateDataTrafficNotificationSetting("server-id", "WEEKLY", "1", "GB")
+				ctx := context.Background()
+				return DedicatedRackApi{}.CreateDataTrafficNotificationSetting(ctx, "server-id", "WEEKLY", "1", "GB")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2935,7 +3058,8 @@ func TestDedicatedRackCreateDataTrafficNotificationSettingServerErrors(t *testin
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.CreateDataTrafficNotificationSetting("server-id", "WEEKLY", "1", "GB")
+				ctx := context.Background()
+				return DedicatedRackApi{}.CreateDataTrafficNotificationSetting(ctx, "server-id", "WEEKLY", "1", "GB")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2952,7 +3076,8 @@ func TestDedicatedRackCreateDataTrafficNotificationSettingServerErrors(t *testin
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.CreateDataTrafficNotificationSetting("server-id", "WEEKLY", "1", "GB")
+				ctx := context.Background()
+				return DedicatedRackApi{}.CreateDataTrafficNotificationSetting(ctx, "server-id", "WEEKLY", "1", "GB")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2969,7 +3094,8 @@ func TestDedicatedRackCreateDataTrafficNotificationSettingServerErrors(t *testin
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.CreateDataTrafficNotificationSetting("server-id", "WEEKLY", "1", "GB")
+				ctx := context.Background()
+				return DedicatedRackApi{}.CreateDataTrafficNotificationSetting(ctx, "server-id", "WEEKLY", "1", "GB")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2986,7 +3112,8 @@ func TestDedicatedRackCreateDataTrafficNotificationSettingServerErrors(t *testin
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.CreateDataTrafficNotificationSetting("server-id", "WEEKLY", "1", "GB")
+				ctx := context.Background()
+				return DedicatedRackApi{}.CreateDataTrafficNotificationSetting(ctx, "server-id", "WEEKLY", "1", "GB")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3006,7 +3133,8 @@ func TestDedicatedRackDeleteDataTrafficNotificationSetting(t *testing.T) {
 	})
 	defer teardown()
 
-	err := DedicatedRackApi{}.DeleteDataTrafficNotificationSetting("server id", "notification id")
+	ctx := context.Background()
+	err := DedicatedRackApi{}.DeleteDataTrafficNotificationSetting(ctx, "server id", "notification id")
 	assert := assert.New(t)
 	assert.Nil(err)
 }
@@ -3022,7 +3150,8 @@ func TestDedicatedRackDeleteDataTrafficNotificationSettingServerErrors(t *testin
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedRackApi{}.DeleteDataTrafficNotificationSetting("server id", "notification id")
+				ctx := context.Background()
+				return nil, DedicatedRackApi{}.DeleteDataTrafficNotificationSetting(ctx, "server id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3039,7 +3168,8 @@ func TestDedicatedRackDeleteDataTrafficNotificationSettingServerErrors(t *testin
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedRackApi{}.DeleteDataTrafficNotificationSetting("server id", "notification id")
+				ctx := context.Background()
+				return nil, DedicatedRackApi{}.DeleteDataTrafficNotificationSetting(ctx, "server id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3056,7 +3186,8 @@ func TestDedicatedRackDeleteDataTrafficNotificationSettingServerErrors(t *testin
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedRackApi{}.DeleteDataTrafficNotificationSetting("server id", "notification id")
+				ctx := context.Background()
+				return nil, DedicatedRackApi{}.DeleteDataTrafficNotificationSetting(ctx, "server id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3073,7 +3204,8 @@ func TestDedicatedRackDeleteDataTrafficNotificationSettingServerErrors(t *testin
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedRackApi{}.DeleteDataTrafficNotificationSetting("server id", "notification id")
+				ctx := context.Background()
+				return nil, DedicatedRackApi{}.DeleteDataTrafficNotificationSetting(ctx, "server id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3090,7 +3222,8 @@ func TestDedicatedRackDeleteDataTrafficNotificationSettingServerErrors(t *testin
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedRackApi{}.DeleteDataTrafficNotificationSetting("server id", "notification id")
+				ctx := context.Background()
+				return nil, DedicatedRackApi{}.DeleteDataTrafficNotificationSetting(ctx, "server id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3123,7 +3256,8 @@ func TestDedicatedRackGetDataTrafficNotificationSetting(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := DedicatedRackApi{}.GetDataTrafficNotificationSetting("server-id", "notification id")
+	ctx := context.Background()
+	resp, err := DedicatedRackApi{}.GetDataTrafficNotificationSetting(ctx, "server-id", "notification id")
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -3148,7 +3282,8 @@ func TestDedicatedRackGetDataTrafficNotificationSettingServerErrors(t *testing.T
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetDataTrafficNotificationSetting("server-id", "notification id")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetDataTrafficNotificationSetting(ctx, "server-id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3165,7 +3300,8 @@ func TestDedicatedRackGetDataTrafficNotificationSettingServerErrors(t *testing.T
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetDataTrafficNotificationSetting("server-id", "notification id")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetDataTrafficNotificationSetting(ctx, "server-id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3182,7 +3318,8 @@ func TestDedicatedRackGetDataTrafficNotificationSettingServerErrors(t *testing.T
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetDataTrafficNotificationSetting("server-id", "notification id")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetDataTrafficNotificationSetting(ctx, "server-id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3199,7 +3336,8 @@ func TestDedicatedRackGetDataTrafficNotificationSettingServerErrors(t *testing.T
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetDataTrafficNotificationSetting("server-id", "notification id")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetDataTrafficNotificationSetting(ctx, "server-id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3216,7 +3354,8 @@ func TestDedicatedRackGetDataTrafficNotificationSettingServerErrors(t *testing.T
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetDataTrafficNotificationSetting("server-id", "notification id")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetDataTrafficNotificationSetting(ctx, "server-id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3250,7 +3389,8 @@ func TestDedicatedRackUpdateDataTrafficNotificationSetting(t *testing.T) {
 	defer teardown()
 
 	payload := map[string]string{"frequency": "MONTHLY", "threshold": "2", "unit": "GB"}
-	resp, err := DedicatedRackApi{}.UpdateDataTrafficNotificationSetting("server-id", "notification id", payload)
+	ctx := context.Background()
+	resp, err := DedicatedRackApi{}.UpdateDataTrafficNotificationSetting(ctx, "server-id", "notification id", payload)
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -3276,7 +3416,8 @@ func TestDedicatedRackUpdateDataTrafficNotificationSettingServerErrors(t *testin
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"frequency": "MONTHLY", "threshold": "2", "unit": "GB"}
-				return DedicatedRackApi{}.UpdateDataTrafficNotificationSetting("server-id", "notification id", payload)
+				ctx := context.Background()
+				return DedicatedRackApi{}.UpdateDataTrafficNotificationSetting(ctx, "server-id", "notification id", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3294,7 +3435,8 @@ func TestDedicatedRackUpdateDataTrafficNotificationSettingServerErrors(t *testin
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"frequency": "MONTHLY", "threshold": "2", "unit": "GB"}
-				return DedicatedRackApi{}.UpdateDataTrafficNotificationSetting("server-id", "notification id", payload)
+				ctx := context.Background()
+				return DedicatedRackApi{}.UpdateDataTrafficNotificationSetting(ctx, "server-id", "notification id", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3312,7 +3454,8 @@ func TestDedicatedRackUpdateDataTrafficNotificationSettingServerErrors(t *testin
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"frequency": "MONTHLY", "threshold": "2", "unit": "GB"}
-				return DedicatedRackApi{}.UpdateDataTrafficNotificationSetting("server-id", "notification id", payload)
+				ctx := context.Background()
+				return DedicatedRackApi{}.UpdateDataTrafficNotificationSetting(ctx, "server-id", "notification id", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3330,7 +3473,8 @@ func TestDedicatedRackUpdateDataTrafficNotificationSettingServerErrors(t *testin
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"frequency": "MONTHLY", "threshold": "2", "unit": "GB"}
-				return DedicatedRackApi{}.UpdateDataTrafficNotificationSetting("server-id", "notification id", payload)
+				ctx := context.Background()
+				return DedicatedRackApi{}.UpdateDataTrafficNotificationSetting(ctx, "server-id", "notification id", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3348,7 +3492,8 @@ func TestDedicatedRackUpdateDataTrafficNotificationSettingServerErrors(t *testin
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"frequency": "MONTHLY", "threshold": "2", "unit": "GB"}
-				return DedicatedRackApi{}.UpdateDataTrafficNotificationSetting("server-id", "notification id", payload)
+				ctx := context.Background()
+				return DedicatedRackApi{}.UpdateDataTrafficNotificationSetting(ctx, "server-id", "notification id", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3404,7 +3549,8 @@ func TestDedicatedRackListBandWidthNotificationSettings(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := DedicatedRackApi{}.ListBandWidthNotificationSettings("server-id")
+	ctx := context.Background()
+	resp, err := DedicatedRackApi{}.ListBandWidthNotificationSettings(ctx, "server-id")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(resp.Metadata.TotalCount, 2)
@@ -3461,7 +3607,8 @@ func TestDedicatedRackListBandWidthNotificationSettingsPaginate(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := DedicatedRackApi{}.ListBandWidthNotificationSettings("server-id", 1)
+	ctx := context.Background()
+	resp, err := DedicatedRackApi{}.ListBandWidthNotificationSettings(ctx, "server-id", 1)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(resp.Metadata.TotalCount, 11)
@@ -3490,7 +3637,8 @@ func TestDedicatedRackListBandWidthNotificationSettingsServerErrors(t *testing.T
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.ListBandWidthNotificationSettings("server-id")
+				ctx := context.Background()
+				return DedicatedRackApi{}.ListBandWidthNotificationSettings(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3507,7 +3655,8 @@ func TestDedicatedRackListBandWidthNotificationSettingsServerErrors(t *testing.T
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.ListBandWidthNotificationSettings("server-id")
+				ctx := context.Background()
+				return DedicatedRackApi{}.ListBandWidthNotificationSettings(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3524,7 +3673,8 @@ func TestDedicatedRackListBandWidthNotificationSettingsServerErrors(t *testing.T
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.ListBandWidthNotificationSettings("server-id")
+				ctx := context.Background()
+				return DedicatedRackApi{}.ListBandWidthNotificationSettings(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3541,7 +3691,8 @@ func TestDedicatedRackListBandWidthNotificationSettingsServerErrors(t *testing.T
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.ListBandWidthNotificationSettings("server-id")
+				ctx := context.Background()
+				return DedicatedRackApi{}.ListBandWidthNotificationSettings(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3558,7 +3709,8 @@ func TestDedicatedRackListBandWidthNotificationSettingsServerErrors(t *testing.T
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.ListBandWidthNotificationSettings("server-id")
+				ctx := context.Background()
+				return DedicatedRackApi{}.ListBandWidthNotificationSettings(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3591,7 +3743,8 @@ func TestDedicatedRackCreateBandWidthNotificationSetting(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := DedicatedRackApi{}.CreateBandWidthNotificationSetting("server-id", "WEEKLY", "1", "Gbps")
+	ctx := context.Background()
+	resp, err := DedicatedRackApi{}.CreateBandWidthNotificationSetting(ctx, "server-id", "WEEKLY", "1", "Gbps")
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -3616,7 +3769,8 @@ func TestDedicatedRackCreateBandWidthNotificationSettingServerErrors(t *testing.
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.CreateBandWidthNotificationSetting("server-id", "WEEKLY", "1", "Gbps")
+				ctx := context.Background()
+				return DedicatedRackApi{}.CreateBandWidthNotificationSetting(ctx, "server-id", "WEEKLY", "1", "Gbps")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3633,7 +3787,8 @@ func TestDedicatedRackCreateBandWidthNotificationSettingServerErrors(t *testing.
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.CreateBandWidthNotificationSetting("server-id", "WEEKLY", "1", "Gbps")
+				ctx := context.Background()
+				return DedicatedRackApi{}.CreateBandWidthNotificationSetting(ctx, "server-id", "WEEKLY", "1", "Gbps")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3650,7 +3805,8 @@ func TestDedicatedRackCreateBandWidthNotificationSettingServerErrors(t *testing.
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.CreateBandWidthNotificationSetting("server-id", "WEEKLY", "1", "Gbps")
+				ctx := context.Background()
+				return DedicatedRackApi{}.CreateBandWidthNotificationSetting(ctx, "server-id", "WEEKLY", "1", "Gbps")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3667,7 +3823,8 @@ func TestDedicatedRackCreateBandWidthNotificationSettingServerErrors(t *testing.
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.CreateBandWidthNotificationSetting("server-id", "WEEKLY", "1", "Gbps")
+				ctx := context.Background()
+				return DedicatedRackApi{}.CreateBandWidthNotificationSetting(ctx, "server-id", "WEEKLY", "1", "Gbps")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3684,7 +3841,8 @@ func TestDedicatedRackCreateBandWidthNotificationSettingServerErrors(t *testing.
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.CreateBandWidthNotificationSetting("server-id", "WEEKLY", "1", "Gbps")
+				ctx := context.Background()
+				return DedicatedRackApi{}.CreateBandWidthNotificationSetting(ctx, "server-id", "WEEKLY", "1", "Gbps")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3704,7 +3862,8 @@ func TestDedicatedRackDeleteBandWidthNotificationSetting(t *testing.T) {
 	})
 	defer teardown()
 
-	err := DedicatedRackApi{}.DeleteBandWidthNotificationSetting("server id", "notification id")
+	ctx := context.Background()
+	err := DedicatedRackApi{}.DeleteBandWidthNotificationSetting(ctx, "server id", "notification id")
 	assert := assert.New(t)
 	assert.Nil(err)
 }
@@ -3720,7 +3879,8 @@ func TestDedicatedRackDeleteBandWidthNotificationSettingServerErrors(t *testing.
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedRackApi{}.DeleteBandWidthNotificationSetting("server id", "notification id")
+				ctx := context.Background()
+				return nil, DedicatedRackApi{}.DeleteBandWidthNotificationSetting(ctx, "server id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3737,7 +3897,8 @@ func TestDedicatedRackDeleteBandWidthNotificationSettingServerErrors(t *testing.
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedRackApi{}.DeleteBandWidthNotificationSetting("server id", "notification id")
+				ctx := context.Background()
+				return nil, DedicatedRackApi{}.DeleteBandWidthNotificationSetting(ctx, "server id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3754,7 +3915,8 @@ func TestDedicatedRackDeleteBandWidthNotificationSettingServerErrors(t *testing.
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedRackApi{}.DeleteBandWidthNotificationSetting("server id", "notification id")
+				ctx := context.Background()
+				return nil, DedicatedRackApi{}.DeleteBandWidthNotificationSetting(ctx, "server id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3771,7 +3933,8 @@ func TestDedicatedRackDeleteBandWidthNotificationSettingServerErrors(t *testing.
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedRackApi{}.DeleteBandWidthNotificationSetting("server id", "notification id")
+				ctx := context.Background()
+				return nil, DedicatedRackApi{}.DeleteBandWidthNotificationSetting(ctx, "server id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3788,7 +3951,8 @@ func TestDedicatedRackDeleteBandWidthNotificationSettingServerErrors(t *testing.
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedRackApi{}.DeleteBandWidthNotificationSetting("server id", "notification id")
+				ctx := context.Background()
+				return nil, DedicatedRackApi{}.DeleteBandWidthNotificationSetting(ctx, "server id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3821,7 +3985,8 @@ func TestDedicatedRackGetBandWidthNotificationSetting(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := DedicatedRackApi{}.GetBandWidthNotificationSetting("server-id", "notification id")
+	ctx := context.Background()
+	resp, err := DedicatedRackApi{}.GetBandWidthNotificationSetting(ctx, "server-id", "notification id")
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -3846,7 +4011,8 @@ func TestDedicatedRackGetBandWidthNotificationSettingServerErrors(t *testing.T) 
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetBandWidthNotificationSetting("server-id", "notification id")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetBandWidthNotificationSetting(ctx, "server-id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3863,7 +4029,8 @@ func TestDedicatedRackGetBandWidthNotificationSettingServerErrors(t *testing.T) 
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetBandWidthNotificationSetting("server-id", "notification id")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetBandWidthNotificationSetting(ctx, "server-id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3880,7 +4047,8 @@ func TestDedicatedRackGetBandWidthNotificationSettingServerErrors(t *testing.T) 
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetBandWidthNotificationSetting("server-id", "notification id")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetBandWidthNotificationSetting(ctx, "server-id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3897,7 +4065,8 @@ func TestDedicatedRackGetBandWidthNotificationSettingServerErrors(t *testing.T) 
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetBandWidthNotificationSetting("server-id", "notification id")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetBandWidthNotificationSetting(ctx, "server-id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3914,7 +4083,8 @@ func TestDedicatedRackGetBandWidthNotificationSettingServerErrors(t *testing.T) 
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedRackApi{}.GetBandWidthNotificationSetting("server-id", "notification id")
+				ctx := context.Background()
+				return DedicatedRackApi{}.GetBandWidthNotificationSetting(ctx, "server-id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3948,7 +4118,8 @@ func TestDedicatedRackUpdateBandWidthNotificationSetting(t *testing.T) {
 	defer teardown()
 
 	payload := map[string]string{"frequency": "MONTHLY", "threshold": "2", "unit": "Mbps"}
-	resp, err := DedicatedRackApi{}.UpdateBandWidthNotificationSetting("server-id", "notification id", payload)
+	ctx := context.Background()
+	resp, err := DedicatedRackApi{}.UpdateBandWidthNotificationSetting(ctx, "server-id", "notification id", payload)
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -3974,7 +4145,8 @@ func TestDedicatedRackUpdateBandWidthNotificationSettingServerErrors(t *testing.
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"frequency": "MONTHLY", "threshold": "2", "unit": "Mbps"}
-				return DedicatedRackApi{}.UpdateBandWidthNotificationSetting("server-id", "notification id", payload)
+				ctx := context.Background()
+				return DedicatedRackApi{}.UpdateBandWidthNotificationSetting(ctx, "server-id", "notification id", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3992,7 +4164,8 @@ func TestDedicatedRackUpdateBandWidthNotificationSettingServerErrors(t *testing.
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"frequency": "MONTHLY", "threshold": "2", "unit": "Mbps"}
-				return DedicatedRackApi{}.UpdateBandWidthNotificationSetting("server-id", "notification id", payload)
+				ctx := context.Background()
+				return DedicatedRackApi{}.UpdateBandWidthNotificationSetting(ctx, "server-id", "notification id", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4010,7 +4183,8 @@ func TestDedicatedRackUpdateBandWidthNotificationSettingServerErrors(t *testing.
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"frequency": "MONTHLY", "threshold": "2", "unit": "Mbps"}
-				return DedicatedRackApi{}.UpdateBandWidthNotificationSetting("server-id", "notification id", payload)
+				ctx := context.Background()
+				return DedicatedRackApi{}.UpdateBandWidthNotificationSetting(ctx, "server-id", "notification id", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4028,7 +4202,8 @@ func TestDedicatedRackUpdateBandWidthNotificationSettingServerErrors(t *testing.
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"frequency": "MONTHLY", "threshold": "2", "unit": "Mbps"}
-				return DedicatedRackApi{}.UpdateBandWidthNotificationSetting("server-id", "notification id", payload)
+				ctx := context.Background()
+				return DedicatedRackApi{}.UpdateBandWidthNotificationSetting(ctx, "server-id", "notification id", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4046,7 +4221,8 @@ func TestDedicatedRackUpdateBandWidthNotificationSettingServerErrors(t *testing.
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"frequency": "MONTHLY", "threshold": "2", "unit": "Mbps"}
-				return DedicatedRackApi{}.UpdateBandWidthNotificationSetting("server-id", "notification id", payload)
+				ctx := context.Background()
+				return DedicatedRackApi{}.UpdateBandWidthNotificationSetting(ctx, "server-id", "notification id", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",

--- a/dedicated_server.go
+++ b/dedicated_server.go
@@ -1,6 +1,7 @@
 package leaseweb
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -451,7 +452,7 @@ func (dsa DedicatedServerApi) getPath(endpoint string) string {
 	return "/bareMetals/" + DEDICATED_SERVER_API_VERSION + endpoint
 }
 
-func (dsa DedicatedServerApi) List(args ...interface{}) (*DedicatedServers, error) {
+func (dsa DedicatedServerApi) List(ctx context.Context, args ...interface{}) (*DedicatedServers, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -480,36 +481,36 @@ func (dsa DedicatedServerApi) List(args ...interface{}) (*DedicatedServers, erro
 
 	path := dsa.getPath("/servers?" + v.Encode())
 	result := &DedicatedServers{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) Get(serverId string) (*DedicatedServer, error) {
+func (dsa DedicatedServerApi) Get(ctx context.Context, serverId string) (*DedicatedServer, error) {
 	path := dsa.getPath("/servers/" + serverId)
 	result := &DedicatedServer{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) Update(serverId string, payload map[string]interface{}) error {
+func (dsa DedicatedServerApi) Update(ctx context.Context, serverId string, payload map[string]interface{}) error {
 	path := dsa.getPath("/servers/" + serverId)
-	return doRequest(http.MethodPut, path, nil, payload)
+	return doRequest(ctx, http.MethodPut, path, nil, payload)
 }
 
-func (dsa DedicatedServerApi) GetHardwareInformation(serverId string) (*DedicatedServerHardware, error) {
+func (dsa DedicatedServerApi) GetHardwareInformation(ctx context.Context, serverId string) (*DedicatedServerHardware, error) {
 	path := dsa.getPath("/servers/" + serverId + "/hardwareInfo")
 	result := &DedicatedServerHardware{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) ListIps(serverId string, args ...interface{}) (*Ips, error) {
+func (dsa DedicatedServerApi) ListIps(ctx context.Context, serverId string, args ...interface{}) (*Ips, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -532,49 +533,49 @@ func (dsa DedicatedServerApi) ListIps(serverId string, args ...interface{}) (*Ip
 
 	path := dsa.getPath("/servers/" + serverId + "/ips" + v.Encode())
 	result := &Ips{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) GetIp(serverId, ip string) (*Ip, error) {
+func (dsa DedicatedServerApi) GetIp(ctx context.Context, serverId, ip string) (*Ip, error) {
 	path := dsa.getPath("/servers/" + serverId + "/ips/" + ip)
 	result := &Ip{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) UpdateIp(serverId, ip string, payload map[string]string) (*Ip, error) {
+func (dsa DedicatedServerApi) UpdateIp(ctx context.Context, serverId, ip string, payload map[string]string) (*Ip, error) {
 	path := dsa.getPath("/servers/" + serverId + "/ips/" + ip)
 	result := &Ip{}
-	if err := doRequest(http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) NullRouteAnIp(serverId, ip string) (*Ip, error) {
+func (dsa DedicatedServerApi) NullRouteAnIp(ctx context.Context, serverId, ip string) (*Ip, error) {
 	path := dsa.getPath("/servers/" + serverId + "/ips/" + ip + "/null")
 	result := &Ip{}
-	if err := doRequest(http.MethodPost, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) RemoveNullRouteAnIp(serverId, ip string) (*Ip, error) {
+func (dsa DedicatedServerApi) RemoveNullRouteAnIp(ctx context.Context, serverId, ip string) (*Ip, error) {
 	path := dsa.getPath("/servers/" + serverId + "/ips/" + ip + "/unnull")
 	result := &Ip{}
-	if err := doRequest(http.MethodPost, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) ListNullRoutes(serverId string, args ...int) (*NullRoutes, error) {
+func (dsa DedicatedServerApi) ListNullRoutes(ctx context.Context, serverId string, args ...int) (*NullRoutes, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -585,13 +586,13 @@ func (dsa DedicatedServerApi) ListNullRoutes(serverId string, args ...int) (*Nul
 
 	path := dsa.getPath("/servers/" + serverId + "/nullRouteHistory?" + v.Encode())
 	result := &NullRoutes{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) ListNetworkInterfaces(serverId string, args ...interface{}) (*DedicatedServerNetworkInterfaces, error) {
+func (dsa DedicatedServerApi) ListNetworkInterfaces(ctx context.Context, serverId string, args ...interface{}) (*DedicatedServerNetworkInterfaces, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -602,58 +603,58 @@ func (dsa DedicatedServerApi) ListNetworkInterfaces(serverId string, args ...int
 
 	path := dsa.getPath("/servers/" + serverId + "/networkInterfaces")
 	result := &DedicatedServerNetworkInterfaces{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) CloseAllNetworkInterfaces(serverId string) error {
+func (dsa DedicatedServerApi) CloseAllNetworkInterfaces(ctx context.Context, serverId string) error {
 	path := dsa.getPath("/servers/" + serverId + "/networkInterfaces/close")
-	return doRequest(http.MethodPost, path)
+	return doRequest(ctx, http.MethodPost, path)
 }
 
-func (dsa DedicatedServerApi) OpenAllNetworkInterfaces(serverId string) error {
+func (dsa DedicatedServerApi) OpenAllNetworkInterfaces(ctx context.Context, serverId string) error {
 	path := dsa.getPath("/servers/" + serverId + "/networkInterfaces/open")
-	return doRequest(http.MethodPost, path)
+	return doRequest(ctx, http.MethodPost, path)
 }
 
-func (dsa DedicatedServerApi) GetNetworkInterface(serverId, networkType string) (*DedicatedServerNetworkInterface, error) {
+func (dsa DedicatedServerApi) GetNetworkInterface(ctx context.Context, serverId, networkType string) (*DedicatedServerNetworkInterface, error) {
 	path := dsa.getPath("/servers/" + serverId + "/networkInterfaces/" + networkType)
 	result := &DedicatedServerNetworkInterface{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) CloseNetworkInterface(serverId, networkType string) error {
+func (dsa DedicatedServerApi) CloseNetworkInterface(ctx context.Context, serverId, networkType string) error {
 	path := dsa.getPath("/servers/" + serverId + "/networkInterfaces/" + networkType + "/close")
-	return doRequest(http.MethodPost, path)
+	return doRequest(ctx, http.MethodPost, path)
 }
 
-func (dsa DedicatedServerApi) OpenNetworkInterface(serverId, networkType string) error {
+func (dsa DedicatedServerApi) OpenNetworkInterface(ctx context.Context, serverId, networkType string) error {
 	path := dsa.getPath("/servers/" + serverId + "/networkInterfaces/" + networkType + "/open")
-	return doRequest(http.MethodPost, path)
+	return doRequest(ctx, http.MethodPost, path)
 }
 
-func (dsa DedicatedServerApi) DeleteServerFromPrivateNetwork(serverId, privateNetworkId string) error {
+func (dsa DedicatedServerApi) DeleteServerFromPrivateNetwork(ctx context.Context, serverId, privateNetworkId string) error {
 	path := dsa.getPath("/servers/" + serverId + "/privateNetworks/" + privateNetworkId)
-	return doRequest(http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path)
 }
 
-func (dsa DedicatedServerApi) AddServerToPrivateNetwork(serverId, privateNetworkId string, linkSpeed int) error {
+func (dsa DedicatedServerApi) AddServerToPrivateNetwork(ctx context.Context, serverId, privateNetworkId string, linkSpeed int) error {
 	payload := map[string]int{"linkSpeed": linkSpeed}
 	path := dsa.getPath("/servers/" + serverId + "/privateNetworks/" + privateNetworkId)
-	return doRequest(http.MethodPut, path, nil, payload)
+	return doRequest(ctx, http.MethodPut, path, nil, payload)
 }
 
-func (dsa DedicatedServerApi) DeleteDhcpReservation(serverId string) error {
+func (dsa DedicatedServerApi) DeleteDhcpReservation(ctx context.Context, serverId string) error {
 	path := dsa.getPath("/servers/" + serverId + "/leases")
-	return doRequest(http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path)
 }
 
-func (dsa DedicatedServerApi) ListDhcpReservation(serverId string, args ...interface{}) (*DedicatedServerDhcpReservations, error) {
+func (dsa DedicatedServerApi) ListDhcpReservation(ctx context.Context, serverId string, args ...interface{}) (*DedicatedServerDhcpReservations, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -663,63 +664,63 @@ func (dsa DedicatedServerApi) ListDhcpReservation(serverId string, args ...inter
 	}
 	path := dsa.getPath("/servers/" + serverId + "/leases" + v.Encode())
 	result := &DedicatedServerDhcpReservations{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) CreateDhcpReservation(serverId string, payload map[string]string) error {
+func (dsa DedicatedServerApi) CreateDhcpReservation(ctx context.Context, serverId string, payload map[string]string) error {
 	path := dsa.getPath("/servers/" + serverId + "/leases")
-	return doRequest(http.MethodPost, path, nil, payload)
+	return doRequest(ctx, http.MethodPost, path, nil, payload)
 }
 
-func (dsa DedicatedServerApi) CancelActiveJob(serverId string) (*DedicatedServerJob, error) {
+func (dsa DedicatedServerApi) CancelActiveJob(ctx context.Context, serverId string) (*DedicatedServerJob, error) {
 	result := &DedicatedServerJob{}
 	path := dsa.getPath("/servers/" + serverId + "/cancelActiveJob")
-	if err := doRequest(http.MethodPost, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) ExpireActiveJob(serverId string) (*DedicatedServerJob, error) {
+func (dsa DedicatedServerApi) ExpireActiveJob(ctx context.Context, serverId string) (*DedicatedServerJob, error) {
 	result := &DedicatedServerJob{}
 	path := dsa.getPath("/servers/" + serverId + "/expireActiveJob")
-	if err := doRequest(http.MethodPost, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) LaunchHardwareScan(serverId string, payload map[string]interface{}) (*DedicatedServerJob, error) {
+func (dsa DedicatedServerApi) LaunchHardwareScan(ctx context.Context, serverId string, payload map[string]interface{}) (*DedicatedServerJob, error) {
 	result := &DedicatedServerJob{}
 	path := dsa.getPath("/servers/" + serverId + "/hardwareScan")
-	if err := doRequest(http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) LaunchInstallation(serverId string, payload map[string]interface{}) (*DedicatedServerJob, error) {
+func (dsa DedicatedServerApi) LaunchInstallation(ctx context.Context, serverId string, payload map[string]interface{}) (*DedicatedServerJob, error) {
 	result := &DedicatedServerJob{}
 	path := dsa.getPath("/servers/" + serverId + "/install")
-	if err := doRequest(http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) LaunchIpmiRest(serverId string, payload map[string]interface{}) (*DedicatedServerJob, error) {
+func (dsa DedicatedServerApi) LaunchIpmiRest(ctx context.Context, serverId string, payload map[string]interface{}) (*DedicatedServerJob, error) {
 	result := &DedicatedServerJob{}
 	path := dsa.getPath("/servers/" + serverId + "/ipmiRest")
-	if err := doRequest(http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) ListJobs(serverId string, args ...int) (*DedicatedServerJobs, error) {
+func (dsa DedicatedServerApi) ListJobs(ctx context.Context, serverId string, args ...int) (*DedicatedServerJobs, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -739,31 +740,31 @@ func (dsa DedicatedServerApi) ListJobs(serverId string, args ...int) (*Dedicated
 
 	result := &DedicatedServerJobs{}
 	path := dsa.getPath("/servers/" + serverId + "/jobs?" + v.Encode())
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) GetJob(serverId, jobId string) (*DedicatedServerJob, error) {
+func (dsa DedicatedServerApi) GetJob(ctx context.Context, serverId, jobId string) (*DedicatedServerJob, error) {
 	result := &DedicatedServerJob{}
 	path := dsa.getPath("/servers/" + serverId + "/jobs/" + jobId)
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) LaunchRescueMode(serverId string, payload map[string]interface{}) (*DedicatedServerJob, error) {
+func (dsa DedicatedServerApi) LaunchRescueMode(ctx context.Context, serverId string, payload map[string]interface{}) (*DedicatedServerJob, error) {
 	result := &DedicatedServerJob{}
 	path := dsa.getPath("/servers/" + serverId + "/rescueMode")
-	if err := doRequest(http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) ListCredentials(serverId string, args ...int) (*Credentials, error) {
+func (dsa DedicatedServerApi) ListCredentials(ctx context.Context, serverId string, args ...int) (*Credentials, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -774,26 +775,26 @@ func (dsa DedicatedServerApi) ListCredentials(serverId string, args ...int) (*Cr
 
 	result := &Credentials{}
 	path := dsa.getPath("/servers/" + serverId + "/credentials?" + v.Encode())
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) CreateCredential(serverId, credentialType, username, password string) (*Credential, error) {
+func (dsa DedicatedServerApi) CreateCredential(ctx context.Context, serverId, credentialType, username, password string) (*Credential, error) {
 	result := &Credential{}
 	payload := make(map[string]string)
 	payload["type"] = credentialType
 	payload["username"] = username
 	payload["password"] = password
 	path := dsa.getPath("/servers/" + serverId + "/credentials")
-	if err := doRequest(http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) ListCredentialsByType(serverId, credentialType string, args ...int) (*Credentials, error) {
+func (dsa DedicatedServerApi) ListCredentialsByType(ctx context.Context, serverId, credentialType string, args ...int) (*Credentials, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -804,37 +805,37 @@ func (dsa DedicatedServerApi) ListCredentialsByType(serverId, credentialType str
 
 	result := &Credentials{}
 	path := dsa.getPath("/servers/" + serverId + "/credentials/" + credentialType + "?" + v.Encode())
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) GetCredential(serverId, credentialType, username string) (*Credential, error) {
+func (dsa DedicatedServerApi) GetCredential(ctx context.Context, serverId, credentialType, username string) (*Credential, error) {
 	result := &Credential{}
 	path := dsa.getPath("/servers/" + serverId + "/credentials/" + credentialType + "/" + username)
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) DeleteCredential(serverId, credentialType, username string) error {
+func (dsa DedicatedServerApi) DeleteCredential(ctx context.Context, serverId, credentialType, username string) error {
 	path := dsa.getPath("/servers/" + serverId + "/credentials/" + credentialType + "/" + username)
-	return doRequest(http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path)
 }
 
-func (dsa DedicatedServerApi) UpdateCredential(serverId, credentialType, username, password string) (*Credential, error) {
+func (dsa DedicatedServerApi) UpdateCredential(ctx context.Context, serverId, credentialType, username, password string) (*Credential, error) {
 	result := &Credential{}
 	payload := map[string]string{"password": password}
 	path := dsa.getPath("/servers/" + serverId + "/credentials/" + credentialType + "/" + username)
-	if err := doRequest(http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) GetDataTrafficMetrics(serverId string, args ...interface{}) (*DataTrafficMetricsV1, error) {
+func (dsa DedicatedServerApi) GetDataTrafficMetrics(ctx context.Context, serverId string, args ...interface{}) (*DataTrafficMetricsV1, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("granularity", fmt.Sprint(args[0]))
@@ -851,13 +852,13 @@ func (dsa DedicatedServerApi) GetDataTrafficMetrics(serverId string, args ...int
 
 	path := dsa.getPath("/servers/" + serverId + "/metrics/datatraffic?" + v.Encode())
 	result := &DataTrafficMetricsV1{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) GetBandWidthMetrics(serverId string, args ...interface{}) (*BandWidthMetrics, error) {
+func (dsa DedicatedServerApi) GetBandWidthMetrics(ctx context.Context, serverId string, args ...interface{}) (*BandWidthMetrics, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("granularity", fmt.Sprint(args[0]))
@@ -874,13 +875,13 @@ func (dsa DedicatedServerApi) GetBandWidthMetrics(serverId string, args ...inter
 
 	path := dsa.getPath("/servers/" + serverId + "/metrics/bandwidth?" + v.Encode())
 	result := &BandWidthMetrics{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) ListBandWidthNotificationSettings(serverId string, args ...int) (*BandWidthNotificationSettings, error) {
+func (dsa DedicatedServerApi) ListBandWidthNotificationSettings(ctx context.Context, serverId string, args ...int) (*BandWidthNotificationSettings, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -891,13 +892,13 @@ func (dsa DedicatedServerApi) ListBandWidthNotificationSettings(serverId string,
 
 	result := &BandWidthNotificationSettings{}
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/bandwidth?" + v.Encode())
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) CreateBandWidthNotificationSetting(serverId, frequency, threshold, unit string) (*NotificationSetting, error) {
+func (dsa DedicatedServerApi) CreateBandWidthNotificationSetting(ctx context.Context, serverId, frequency, threshold, unit string) (*NotificationSetting, error) {
 	payload := map[string]string{
 		"frequency": frequency,
 		"threshold": threshold,
@@ -905,36 +906,36 @@ func (dsa DedicatedServerApi) CreateBandWidthNotificationSetting(serverId, frequ
 	}
 	result := &NotificationSetting{}
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/bandwidth")
-	if err := doRequest(http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) DeleteBandWidthNotificationSetting(serverId, notificationId string) error {
+func (dsa DedicatedServerApi) DeleteBandWidthNotificationSetting(ctx context.Context, serverId, notificationId string) error {
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/bandwidth/" + notificationId)
-	return doRequest(http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path)
 }
 
-func (dsa DedicatedServerApi) GetBandWidthNotificationSetting(serverId, notificationId string) (*NotificationSetting, error) {
+func (dsa DedicatedServerApi) GetBandWidthNotificationSetting(ctx context.Context, serverId, notificationId string) (*NotificationSetting, error) {
 	result := &NotificationSetting{}
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/bandwidth/" + notificationId)
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) UpdateBandWidthNotificationSetting(serverId, notificationSettingId string, payload map[string]string) (*NotificationSetting, error) {
+func (dsa DedicatedServerApi) UpdateBandWidthNotificationSetting(ctx context.Context, serverId, notificationSettingId string, payload map[string]string) (*NotificationSetting, error) {
 	result := &NotificationSetting{}
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/bandwidth/" + notificationSettingId)
-	if err := doRequest(http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) ListDataTrafficNotificationSettings(serverId string, args ...int) (*DataTrafficNotificationSettings, error) {
+func (dsa DedicatedServerApi) ListDataTrafficNotificationSettings(ctx context.Context, serverId string, args ...int) (*DataTrafficNotificationSettings, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -945,13 +946,13 @@ func (dsa DedicatedServerApi) ListDataTrafficNotificationSettings(serverId strin
 
 	result := &DataTrafficNotificationSettings{}
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/datatraffic?" + v.Encode())
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) CreateDataTrafficNotificationSetting(serverId, frequency, threshold, unit string) (*NotificationSetting, error) {
+func (dsa DedicatedServerApi) CreateDataTrafficNotificationSetting(ctx context.Context, serverId, frequency, threshold, unit string) (*NotificationSetting, error) {
 	payload := map[string]string{
 		"frequency": frequency,
 		"threshold": threshold,
@@ -959,77 +960,77 @@ func (dsa DedicatedServerApi) CreateDataTrafficNotificationSetting(serverId, fre
 	}
 	result := &NotificationSetting{}
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/datatraffic")
-	if err := doRequest(http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) DeleteDataTrafficNotificationSetting(serverId, notificationId string) error {
+func (dsa DedicatedServerApi) DeleteDataTrafficNotificationSetting(ctx context.Context, serverId, notificationId string) error {
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/datatraffic/" + notificationId)
-	return doRequest(http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path)
 }
 
-func (dsa DedicatedServerApi) GetDataTrafficNotificationSetting(serverId, notificationId string) (*NotificationSetting, error) {
+func (dsa DedicatedServerApi) GetDataTrafficNotificationSetting(ctx context.Context, serverId, notificationId string) (*NotificationSetting, error) {
 	result := &NotificationSetting{}
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/datatraffic/" + notificationId)
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) UpdateDataTrafficNotificationSetting(serverId, notificationSettingId string, payload map[string]string) (*NotificationSetting, error) {
+func (dsa DedicatedServerApi) UpdateDataTrafficNotificationSetting(ctx context.Context, serverId, notificationSettingId string, payload map[string]string) (*NotificationSetting, error) {
 	result := &NotificationSetting{}
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/datatraffic/" + notificationSettingId)
-	if err := doRequest(http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) GetDdosNotificationSetting(serverId string) (*DdosNotificationSetting, error) {
+func (dsa DedicatedServerApi) GetDdosNotificationSetting(ctx context.Context, serverId string) (*DdosNotificationSetting, error) {
 	result := &DdosNotificationSetting{}
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/ddos")
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) UpdateDdosNotificationSetting(serverId string, payload map[string]string) error {
+func (dsa DedicatedServerApi) UpdateDdosNotificationSetting(ctx context.Context, serverId string, payload map[string]string) error {
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/ddos/")
-	if err := doRequest(http.MethodPut, path, nil, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, nil, payload); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (dsa DedicatedServerApi) PowerCycleServer(serverId string) error {
+func (dsa DedicatedServerApi) PowerCycleServer(ctx context.Context, serverId string) error {
 	path := dsa.getPath("/servers/" + serverId + "/powerCycle")
-	return doRequest(http.MethodPost, path)
+	return doRequest(ctx, http.MethodPost, path)
 }
 
-func (dsa DedicatedServerApi) GetPowerStatus(serverId string) (*PowerStatus, error) {
+func (dsa DedicatedServerApi) GetPowerStatus(ctx context.Context, serverId string) (*PowerStatus, error) {
 	result := &PowerStatus{}
 	path := dsa.getPath("/servers/" + serverId + "/powerInfo")
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) PowerOffServer(serverId string) error {
+func (dsa DedicatedServerApi) PowerOffServer(ctx context.Context, serverId string) error {
 	path := dsa.getPath("/servers/" + serverId + "/powerOff")
-	return doRequest(http.MethodPost, path)
+	return doRequest(ctx, http.MethodPost, path)
 }
 
-func (dsa DedicatedServerApi) PowerOnServer(serverId string) error {
+func (dsa DedicatedServerApi) PowerOnServer(ctx context.Context, serverId string) error {
 	path := dsa.getPath("/servers/" + serverId + "/powerOn")
-	return doRequest(http.MethodPost, path)
+	return doRequest(ctx, http.MethodPost, path)
 }
 
-func (dsa DedicatedServerApi) ListOperatingSystems(args ...interface{}) (*DedicatedServerOperatingSystems, error) {
+func (dsa DedicatedServerApi) ListOperatingSystems(ctx context.Context, args ...interface{}) (*DedicatedServerOperatingSystems, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -1043,24 +1044,24 @@ func (dsa DedicatedServerApi) ListOperatingSystems(args ...interface{}) (*Dedica
 
 	result := &DedicatedServerOperatingSystems{}
 	path := dsa.getPath("/operatingSystems?" + v.Encode())
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) GetOperatingSystem(operatingSystemId, controlPanelId string) (*DedicatedServerOperatingSystem, error) {
+func (dsa DedicatedServerApi) GetOperatingSystem(ctx context.Context, operatingSystemId, controlPanelId string) (*DedicatedServerOperatingSystem, error) {
 	v := url.Values{}
 	v.Add("controlPanelId", fmt.Sprint(controlPanelId))
 	result := &DedicatedServerOperatingSystem{}
 	path := dsa.getPath("/operatingSystems/" + operatingSystemId + "?" + v.Encode())
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) ListControlPanels(args ...interface{}) (*DedicatedServerControlPanels, error) {
+func (dsa DedicatedServerApi) ListControlPanels(ctx context.Context, args ...interface{}) (*DedicatedServerControlPanels, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -1074,13 +1075,13 @@ func (dsa DedicatedServerApi) ListControlPanels(args ...interface{}) (*Dedicated
 
 	result := &DedicatedServerControlPanels{}
 	path := dsa.getPath("/controlPanels?" + v.Encode())
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return result, err
 	}
 	return result, nil
 }
 
-func (dsa DedicatedServerApi) ListRescueImages(args ...interface{}) (*DedicatedServerRescueImages, error) {
+func (dsa DedicatedServerApi) ListRescueImages(ctx context.Context, args ...interface{}) (*DedicatedServerRescueImages, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -1091,7 +1092,7 @@ func (dsa DedicatedServerApi) ListRescueImages(args ...interface{}) (*DedicatedS
 
 	result := &DedicatedServerRescueImages{}
 	path := dsa.getPath("/rescueImages?" + v.Encode())
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return result, err
 	}
 	return result, nil

--- a/dedicated_server_test.go
+++ b/dedicated_server_test.go
@@ -1,6 +1,7 @@
 package leaseweb
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -84,7 +85,8 @@ func TestDedicatedServerList(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedServerApi{}.List()
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.List(ctx)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 1)
@@ -149,7 +151,8 @@ func TestDedicatedServerListBeEmpty(t *testing.T) {
 		fmt.Fprintf(w, `{"_metadata":{"limit": 10, "offset": 0, "totalCount": 0}, "servers": []}`)
 	})
 	defer teardown()
-	response, err := DedicatedServerApi{}.List()
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.List(ctx)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 0)
@@ -234,7 +237,8 @@ func TestDedicatedServerListPaginateAndFilter(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedServerApi{}.List(1, 10, "10.22.192.3", "AA:BB:CC:DD:EE:FF", "AMS-01")
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.List(ctx, 1, 10, "10.22.192.3", "AA:BB:CC:DD:EE:FF", "AMS-01")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 11)
@@ -303,7 +307,8 @@ func TestDedicatedServerListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.List()
+				ctx := context.Background()
+				return DedicatedServerApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -320,7 +325,8 @@ func TestDedicatedServerListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.List()
+				ctx := context.Background()
+				return DedicatedServerApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -337,7 +343,8 @@ func TestDedicatedServerListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.List()
+				ctx := context.Background()
+				return DedicatedServerApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -354,7 +361,8 @@ func TestDedicatedServerListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.List()
+				ctx := context.Background()
+				return DedicatedServerApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -487,7 +495,8 @@ func TestDedicatedServerGet(t *testing.T) {
 	})
 	defer teardown()
 
-	Server, err := DedicatedServerApi{}.Get("12345")
+	ctx := context.Background()
+	Server, err := DedicatedServerApi{}.Get(ctx, "12345")
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -585,7 +594,8 @@ func TestDedicatedServerGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.Get("12345")
+				ctx := context.Background()
+				return DedicatedServerApi{}.Get(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -602,7 +612,8 @@ func TestDedicatedServerGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.Get("12345")
+				ctx := context.Background()
+				return DedicatedServerApi{}.Get(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -619,7 +630,8 @@ func TestDedicatedServerGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.Get("12345")
+				ctx := context.Background()
+				return DedicatedServerApi{}.Get(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -636,7 +648,8 @@ func TestDedicatedServerGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.Get("12345")
+				ctx := context.Background()
+				return DedicatedServerApi{}.Get(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -653,7 +666,8 @@ func TestDedicatedServerGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.Get("12345")
+				ctx := context.Background()
+				return DedicatedServerApi{}.Get(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -674,7 +688,8 @@ func TestDedicatedServerUpdate(t *testing.T) {
 	defer teardown()
 
 	payload := map[string]interface{}{"reference": "new reference"}
-	err := DedicatedServerApi{}.Update("12345", payload)
+	ctx := context.Background()
+	err := DedicatedServerApi{}.Update(ctx, "12345", payload)
 	assert := assert.New(t)
 	assert.Nil(err)
 }
@@ -691,7 +706,8 @@ func TestDedicatedServerUpdateServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]interface{}{"reference": "new reference"}
-				return nil, DedicatedServerApi{}.Update("12345", payload)
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.Update(ctx, "12345", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -709,7 +725,8 @@ func TestDedicatedServerUpdateServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]interface{}{"reference": "new reference"}
-				return nil, DedicatedServerApi{}.Update("12345", payload)
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.Update(ctx, "12345", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -727,7 +744,8 @@ func TestDedicatedServerUpdateServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]interface{}{"reference": "new reference"}
-				return nil, DedicatedServerApi{}.Update("12345", payload)
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.Update(ctx, "12345", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -745,7 +763,8 @@ func TestDedicatedServerUpdateServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]interface{}{"reference": "new reference"}
-				return nil, DedicatedServerApi{}.Update("12345", payload)
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.Update(ctx, "12345", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -763,7 +782,8 @@ func TestDedicatedServerUpdateServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]interface{}{"reference": "new reference"}
-				return nil, DedicatedServerApi{}.Update("12345", payload)
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.Update(ctx, "12345", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -965,7 +985,8 @@ func TestDedicatedServerGetHardwareInformation(t *testing.T) {
 	})
 	defer teardown()
 
-	Server, err := DedicatedServerApi{}.GetHardwareInformation("2378237")
+	ctx := context.Background()
+	Server, err := DedicatedServerApi{}.GetHardwareInformation(ctx, "2378237")
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -1122,7 +1143,8 @@ func TestDedicatedServerGetHardwareInformationServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetHardwareInformation("2378237")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetHardwareInformation(ctx, "2378237")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1139,7 +1161,8 @@ func TestDedicatedServerGetHardwareInformationServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetHardwareInformation("2378237")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetHardwareInformation(ctx, "2378237")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1156,7 +1179,8 @@ func TestDedicatedServerGetHardwareInformationServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetHardwareInformation("2378237")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetHardwareInformation(ctx, "2378237")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1173,7 +1197,8 @@ func TestDedicatedServerGetHardwareInformationServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetHardwareInformation("2378237")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetHardwareInformation(ctx, "2378237")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1190,7 +1215,8 @@ func TestDedicatedServerGetHardwareInformationServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetHardwareInformation("2378237")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetHardwareInformation(ctx, "2378237")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1246,7 +1272,8 @@ func TestDedicatedServerListIps(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedServerApi{}.ListIps("server-id")
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.ListIps(ctx, "server-id")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 2)
@@ -1286,7 +1313,8 @@ func TestDedicatedServerListIpsBeEmpty(t *testing.T) {
 		fmt.Fprintf(w, `{"_metadata":{"limit": 10, "offset": 0, "totalCount": 0}, "ips": []}`)
 	})
 	defer teardown()
-	response, err := DedicatedServerApi{}.ListIps("server-id")
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.ListIps(ctx, "server-id")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 0)
@@ -1325,7 +1353,8 @@ func TestDedicatedServerListIpsFilterAndPagination(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedServerApi{}.ListIps("server-id", 1, 10)
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.ListIps(ctx, "server-id", 1, 10)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 11)
@@ -1357,7 +1386,8 @@ func TestDedicatedServerListIpsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListIps("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListIps(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1374,7 +1404,8 @@ func TestDedicatedServerListIpsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListIps("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListIps(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1391,7 +1422,8 @@ func TestDedicatedServerListIpsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListIps("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListIps(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1408,7 +1440,8 @@ func TestDedicatedServerListIpsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListIps("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListIps(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1441,7 +1474,8 @@ func TestDedicatedServerGetIp(t *testing.T) {
 	})
 	defer teardown()
 
-	Ip, err := DedicatedServerApi{}.GetIp("12345", "127.0.0.6")
+	ctx := context.Background()
+	Ip, err := DedicatedServerApi{}.GetIp(ctx, "12345", "127.0.0.6")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(Ip.DDOS.DetectionProfile, "ADVANCED_LOW_UDP")
@@ -1467,7 +1501,8 @@ func TestDedicatedServerGetIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1484,7 +1519,8 @@ func TestDedicatedServerGetIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1501,7 +1537,8 @@ func TestDedicatedServerGetIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1518,7 +1555,8 @@ func TestDedicatedServerGetIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1535,7 +1573,8 @@ func TestDedicatedServerGetIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1569,7 +1608,8 @@ func TestDedicatedServerUpdateIp(t *testing.T) {
 	defer teardown()
 
 	payload := map[string]string{"detectionProfile": "ADVANCED_DEFAULT", "reverseLookup": "domain.example.com"}
-	Ip, err := DedicatedServerApi{}.UpdateIp("12345", "127.0.0.6", payload)
+	ctx := context.Background()
+	Ip, err := DedicatedServerApi{}.UpdateIp(ctx, "12345", "127.0.0.6", payload)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(Ip.DDOS.DetectionProfile, "ADVANCED_DEFAULT")
@@ -1596,7 +1636,8 @@ func TestDedicatedServerUpdateIpServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"detectionProfile": "ADVANCED_DEFAULT", "reverseLookup": "domain.example.com"}
-				return DedicatedServerApi{}.UpdateIp("12345", "127.0.0.6", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.UpdateIp(ctx, "12345", "127.0.0.6", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1614,7 +1655,8 @@ func TestDedicatedServerUpdateIpServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"detectionProfile": "ADVANCED_DEFAULT", "reverseLookup": "domain.example.com"}
-				return DedicatedServerApi{}.UpdateIp("12345", "127.0.0.6", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.UpdateIp(ctx, "12345", "127.0.0.6", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1632,7 +1674,8 @@ func TestDedicatedServerUpdateIpServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"detectionProfile": "ADVANCED_DEFAULT", "reverseLookup": "domain.example.com"}
-				return DedicatedServerApi{}.UpdateIp("12345", "127.0.0.6", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.UpdateIp(ctx, "12345", "127.0.0.6", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1650,7 +1693,8 @@ func TestDedicatedServerUpdateIpServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"detectionProfile": "ADVANCED_DEFAULT", "reverseLookup": "domain.example.com"}
-				return DedicatedServerApi{}.UpdateIp("12345", "127.0.0.6", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.UpdateIp(ctx, "12345", "127.0.0.6", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1668,7 +1712,8 @@ func TestDedicatedServerUpdateIpServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"detectionProfile": "ADVANCED_DEFAULT", "reverseLookup": "domain.example.com"}
-				return DedicatedServerApi{}.UpdateIp("12345", "127.0.0.6", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.UpdateIp(ctx, "12345", "127.0.0.6", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1701,7 +1746,8 @@ func TestDedicatedServerNullRouteAnIp(t *testing.T) {
 	})
 	defer teardown()
 
-	Ip, err := DedicatedServerApi{}.NullRouteAnIp("12345", "127.0.0.6")
+	ctx := context.Background()
+	Ip, err := DedicatedServerApi{}.NullRouteAnIp(ctx, "12345", "127.0.0.6")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(Ip.DDOS.DetectionProfile, "ADVANCED_DEFAULT")
@@ -1727,7 +1773,8 @@ func TestDedicatedServerNullRouteAnIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.NullRouteAnIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedServerApi{}.NullRouteAnIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1744,7 +1791,8 @@ func TestDedicatedServerNullRouteAnIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.NullRouteAnIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedServerApi{}.NullRouteAnIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1761,7 +1809,8 @@ func TestDedicatedServerNullRouteAnIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.NullRouteAnIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedServerApi{}.NullRouteAnIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1778,7 +1827,8 @@ func TestDedicatedServerNullRouteAnIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.NullRouteAnIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedServerApi{}.NullRouteAnIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1795,7 +1845,8 @@ func TestDedicatedServerNullRouteAnIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.NullRouteAnIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedServerApi{}.NullRouteAnIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1828,7 +1879,8 @@ func TestDedicatedServerRemoveNullRouteAnIp(t *testing.T) {
 	})
 	defer teardown()
 
-	Ip, err := DedicatedServerApi{}.RemoveNullRouteAnIp("12345", "127.0.0.6")
+	ctx := context.Background()
+	Ip, err := DedicatedServerApi{}.RemoveNullRouteAnIp(ctx, "12345", "127.0.0.6")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(Ip.DDOS.DetectionProfile, "ADVANCED_DEFAULT")
@@ -1854,7 +1906,8 @@ func TestDedicatedServerRemoveNullRouteAnIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.RemoveNullRouteAnIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedServerApi{}.RemoveNullRouteAnIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1871,7 +1924,8 @@ func TestDedicatedServerRemoveNullRouteAnIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.RemoveNullRouteAnIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedServerApi{}.RemoveNullRouteAnIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1888,7 +1942,8 @@ func TestDedicatedServerRemoveNullRouteAnIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.RemoveNullRouteAnIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedServerApi{}.RemoveNullRouteAnIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1905,7 +1960,8 @@ func TestDedicatedServerRemoveNullRouteAnIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.RemoveNullRouteAnIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedServerApi{}.RemoveNullRouteAnIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1922,7 +1978,8 @@ func TestDedicatedServerRemoveNullRouteAnIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.RemoveNullRouteAnIp("12345", "127.0.0.6")
+				ctx := context.Background()
+				return DedicatedServerApi{}.RemoveNullRouteAnIp(ctx, "12345", "127.0.0.6")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1958,7 +2015,8 @@ func TestDedicatedServerListNullRoutes(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedServerApi{}.ListNullRoutes("server-id")
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.ListNullRoutes(ctx, "server-id")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 1)
@@ -1982,7 +2040,8 @@ func TestDedicatedServerListNullRoutesBeEmpty(t *testing.T) {
 		fmt.Fprintf(w, `{"_metadata":{"limit": 10, "offset": 0, "totalCount": 0}, "nullRoutes": []}`)
 	})
 	defer teardown()
-	response, err := DedicatedServerApi{}.ListNullRoutes("server-id")
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.ListNullRoutes(ctx, "server-id")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 0)
@@ -2015,7 +2074,8 @@ func TestDedicatedServerListNullRoutesFilterAndPagination(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedServerApi{}.ListNullRoutes("server-id", 1)
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.ListNullRoutes(ctx, "server-id", 1)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 11)
@@ -2043,7 +2103,8 @@ func TestDedicatedServerListNullRoutesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListNullRoutes("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListNullRoutes(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2060,7 +2121,8 @@ func TestDedicatedServerListNullRoutesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListNullRoutes("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListNullRoutes(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2077,7 +2139,8 @@ func TestDedicatedServerListNullRoutesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListNullRoutes("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListNullRoutes(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2094,7 +2157,8 @@ func TestDedicatedServerListNullRoutesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListNullRoutes("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListNullRoutes(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2130,7 +2194,8 @@ func TestDedicatedServerListNetworkInterfaces(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedServerApi{}.ListNetworkInterfaces("server-id")
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.ListNetworkInterfaces(ctx, "server-id")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 1)
@@ -2154,7 +2219,8 @@ func TestDedicatedServerListNetworkInterfacesBeEmpty(t *testing.T) {
 		fmt.Fprintf(w, `{"_metadata":{"limit": 10, "offset": 0, "totalCount": 0}, "networkInterfaces": []}`)
 	})
 	defer teardown()
-	response, err := DedicatedServerApi{}.ListNetworkInterfaces("server-id")
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.ListNetworkInterfaces(ctx, "server-id")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 0)
@@ -2187,7 +2253,8 @@ func TestDedicatedServerListNetworkInterfacesPagination(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedServerApi{}.ListNetworkInterfaces("server-id", 1)
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.ListNetworkInterfaces(ctx, "server-id", 1)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 11)
@@ -2215,7 +2282,8 @@ func TestDedicatedServerListNetworkInterfacesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListNetworkInterfaces("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListNetworkInterfaces(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2232,7 +2300,8 @@ func TestDedicatedServerListNetworkInterfacesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListNetworkInterfaces("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListNetworkInterfaces(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2249,7 +2318,8 @@ func TestDedicatedServerListNetworkInterfacesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListNetworkInterfaces("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListNetworkInterfaces(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2266,7 +2336,8 @@ func TestDedicatedServerListNetworkInterfacesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListNetworkInterfaces("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListNetworkInterfaces(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2286,7 +2357,8 @@ func TestDedicatedServerCloseAllNetworkInterfaces(t *testing.T) {
 	})
 	defer teardown()
 
-	err := DedicatedServerApi{}.CloseAllNetworkInterfaces("12345")
+	ctx := context.Background()
+	err := DedicatedServerApi{}.CloseAllNetworkInterfaces(ctx, "12345")
 	assert := assert.New(t)
 	assert.Nil(err)
 }
@@ -2302,7 +2374,8 @@ func TestDedicatedServerCloseAllNetworkInterfacesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.CloseAllNetworkInterfaces("server-id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.CloseAllNetworkInterfaces(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2319,7 +2392,8 @@ func TestDedicatedServerCloseAllNetworkInterfacesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.CloseAllNetworkInterfaces("server-id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.CloseAllNetworkInterfaces(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2336,7 +2410,8 @@ func TestDedicatedServerCloseAllNetworkInterfacesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.CloseAllNetworkInterfaces("server-id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.CloseAllNetworkInterfaces(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2353,7 +2428,8 @@ func TestDedicatedServerCloseAllNetworkInterfacesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.CloseAllNetworkInterfaces("server-id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.CloseAllNetworkInterfaces(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2370,7 +2446,8 @@ func TestDedicatedServerCloseAllNetworkInterfacesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.CloseAllNetworkInterfaces("server-id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.CloseAllNetworkInterfaces(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2390,7 +2467,8 @@ func TestDedicatedServerOpenAllNetworkInterfaces(t *testing.T) {
 	})
 	defer teardown()
 
-	err := DedicatedServerApi{}.OpenAllNetworkInterfaces("12345")
+	ctx := context.Background()
+	err := DedicatedServerApi{}.OpenAllNetworkInterfaces(ctx, "12345")
 	assert := assert.New(t)
 	assert.Nil(err)
 }
@@ -2406,7 +2484,8 @@ func TestDedicatedServerOpenAllNetworkInterfacesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.OpenAllNetworkInterfaces("server-id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.OpenAllNetworkInterfaces(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2423,7 +2502,8 @@ func TestDedicatedServerOpenAllNetworkInterfacesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.OpenAllNetworkInterfaces("server-id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.OpenAllNetworkInterfaces(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2440,7 +2520,8 @@ func TestDedicatedServerOpenAllNetworkInterfacesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.OpenAllNetworkInterfaces("server-id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.OpenAllNetworkInterfaces(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2457,7 +2538,8 @@ func TestDedicatedServerOpenAllNetworkInterfacesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.OpenAllNetworkInterfaces("server-id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.OpenAllNetworkInterfaces(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2474,7 +2556,8 @@ func TestDedicatedServerOpenAllNetworkInterfacesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.OpenAllNetworkInterfaces("server-id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.OpenAllNetworkInterfaces(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2502,7 +2585,8 @@ func TestDedicatedServerGetNetworkInterface(t *testing.T) {
 	})
 	defer teardown()
 
-	NetworkInterface, err := DedicatedServerApi{}.GetNetworkInterface("server-id", "public")
+	ctx := context.Background()
+	NetworkInterface, err := DedicatedServerApi{}.GetNetworkInterface(ctx, "server-id", "public")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(NetworkInterface.LinkSpeed, "100Mbps")
@@ -2524,7 +2608,8 @@ func TestDedicatedServerGetNetworkInterfaceServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetNetworkInterface("server-id", "public")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetNetworkInterface(ctx, "server-id", "public")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2541,7 +2626,8 @@ func TestDedicatedServerGetNetworkInterfaceServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetNetworkInterface("server-id", "public")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetNetworkInterface(ctx, "server-id", "public")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2558,7 +2644,8 @@ func TestDedicatedServerGetNetworkInterfaceServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetNetworkInterface("server-id", "public")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetNetworkInterface(ctx, "server-id", "public")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2575,7 +2662,8 @@ func TestDedicatedServerGetNetworkInterfaceServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetNetworkInterface("server-id", "public")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetNetworkInterface(ctx, "server-id", "public")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2595,7 +2683,8 @@ func TestDedicatedServerCloseNetworkInterface(t *testing.T) {
 	})
 	defer teardown()
 
-	err := DedicatedServerApi{}.CloseNetworkInterface("12345", "PUBLIC")
+	ctx := context.Background()
+	err := DedicatedServerApi{}.CloseNetworkInterface(ctx, "12345", "PUBLIC")
 	assert := assert.New(t)
 	assert.Nil(err)
 }
@@ -2611,7 +2700,8 @@ func TestDedicatedServerCloseNetworkInterfaceServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.CloseNetworkInterface("12345", "PUBLIC")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.CloseNetworkInterface(ctx, "12345", "PUBLIC")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2628,7 +2718,8 @@ func TestDedicatedServerCloseNetworkInterfaceServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.CloseNetworkInterface("12345", "PUBLIC")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.CloseNetworkInterface(ctx, "12345", "PUBLIC")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2645,7 +2736,8 @@ func TestDedicatedServerCloseNetworkInterfaceServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.CloseNetworkInterface("12345", "PUBLIC")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.CloseNetworkInterface(ctx, "12345", "PUBLIC")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2662,7 +2754,8 @@ func TestDedicatedServerCloseNetworkInterfaceServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.CloseNetworkInterface("12345", "PUBLIC")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.CloseNetworkInterface(ctx, "12345", "PUBLIC")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2679,7 +2772,8 @@ func TestDedicatedServerCloseNetworkInterfaceServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.CloseNetworkInterface("12345", "PUBLIC")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.CloseNetworkInterface(ctx, "12345", "PUBLIC")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2699,7 +2793,8 @@ func TestDedicatedServerOpenNetworkInterface(t *testing.T) {
 	})
 	defer teardown()
 
-	err := DedicatedServerApi{}.OpenNetworkInterface("12345", "PUBLIC")
+	ctx := context.Background()
+	err := DedicatedServerApi{}.OpenNetworkInterface(ctx, "12345", "PUBLIC")
 	assert := assert.New(t)
 	assert.Nil(err)
 }
@@ -2715,7 +2810,8 @@ func TestDedicatedServerOpenNetworkInterfaceServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.OpenNetworkInterface("12345", "PUBLIC")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.OpenNetworkInterface(ctx, "12345", "PUBLIC")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2732,7 +2828,8 @@ func TestDedicatedServerOpenNetworkInterfaceServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.OpenNetworkInterface("12345", "PUBLIC")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.OpenNetworkInterface(ctx, "12345", "PUBLIC")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2749,7 +2846,8 @@ func TestDedicatedServerOpenNetworkInterfaceServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.OpenNetworkInterface("12345", "PUBLIC")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.OpenNetworkInterface(ctx, "12345", "PUBLIC")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2766,7 +2864,8 @@ func TestDedicatedServerOpenNetworkInterfaceServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.OpenNetworkInterface("12345", "PUBLIC")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.OpenNetworkInterface(ctx, "12345", "PUBLIC")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2783,7 +2882,8 @@ func TestDedicatedServerOpenNetworkInterfaceServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.OpenNetworkInterface("12345", "PUBLIC")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.OpenNetworkInterface(ctx, "12345", "PUBLIC")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2803,7 +2903,8 @@ func TestDedicatedServerDeleteServerFromPrivateNetwork(t *testing.T) {
 	})
 	defer teardown()
 
-	err := DedicatedServerApi{}.DeleteServerFromPrivateNetwork("12345", "892")
+	ctx := context.Background()
+	err := DedicatedServerApi{}.DeleteServerFromPrivateNetwork(ctx, "12345", "892")
 	assert := assert.New(t)
 	assert.Nil(err)
 }
@@ -2819,7 +2920,8 @@ func TestDedicatedServerDeleteServerFromPrivateNetworkServerErrors(t *testing.T)
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.DeleteServerFromPrivateNetwork("12345", "892")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.DeleteServerFromPrivateNetwork(ctx, "12345", "892")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2836,7 +2938,8 @@ func TestDedicatedServerDeleteServerFromPrivateNetworkServerErrors(t *testing.T)
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.DeleteServerFromPrivateNetwork("12345", "892")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.DeleteServerFromPrivateNetwork(ctx, "12345", "892")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2853,7 +2956,8 @@ func TestDedicatedServerDeleteServerFromPrivateNetworkServerErrors(t *testing.T)
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.DeleteServerFromPrivateNetwork("12345", "892")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.DeleteServerFromPrivateNetwork(ctx, "12345", "892")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2870,7 +2974,8 @@ func TestDedicatedServerDeleteServerFromPrivateNetworkServerErrors(t *testing.T)
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.DeleteServerFromPrivateNetwork("12345", "892")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.DeleteServerFromPrivateNetwork(ctx, "12345", "892")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2887,7 +2992,8 @@ func TestDedicatedServerDeleteServerFromPrivateNetworkServerErrors(t *testing.T)
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.DeleteServerFromPrivateNetwork("12345", "892")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.DeleteServerFromPrivateNetwork(ctx, "12345", "892")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2907,7 +3013,8 @@ func TestDedicatedServerAddServerToPrivateNetwork(t *testing.T) {
 	})
 	defer teardown()
 
-	err := DedicatedServerApi{}.AddServerToPrivateNetwork("12345", "892", 1000)
+	ctx := context.Background()
+	err := DedicatedServerApi{}.AddServerToPrivateNetwork(ctx, "12345", "892", 1000)
 	assert := assert.New(t)
 	assert.Nil(err)
 }
@@ -2923,7 +3030,8 @@ func TestDedicatedServerAddServerToPrivateNetworkServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.AddServerToPrivateNetwork("12345", "892", 1000)
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.AddServerToPrivateNetwork(ctx, "12345", "892", 1000)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2940,7 +3048,8 @@ func TestDedicatedServerAddServerToPrivateNetworkServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.AddServerToPrivateNetwork("12345", "892", 1000)
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.AddServerToPrivateNetwork(ctx, "12345", "892", 1000)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2957,7 +3066,8 @@ func TestDedicatedServerAddServerToPrivateNetworkServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.AddServerToPrivateNetwork("12345", "892", 1000)
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.AddServerToPrivateNetwork(ctx, "12345", "892", 1000)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2974,7 +3084,8 @@ func TestDedicatedServerAddServerToPrivateNetworkServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.AddServerToPrivateNetwork("12345", "892", 1000)
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.AddServerToPrivateNetwork(ctx, "12345", "892", 1000)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2991,7 +3102,8 @@ func TestDedicatedServerAddServerToPrivateNetworkServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.AddServerToPrivateNetwork("12345", "892", 1000)
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.AddServerToPrivateNetwork(ctx, "12345", "892", 1000)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3011,7 +3123,8 @@ func TestDedicatedServerDeleteDhcpReservation(t *testing.T) {
 	})
 	defer teardown()
 
-	err := DedicatedServerApi{}.DeleteDhcpReservation("12345")
+	ctx := context.Background()
+	err := DedicatedServerApi{}.DeleteDhcpReservation(ctx, "12345")
 	assert := assert.New(t)
 	assert.Nil(err)
 }
@@ -3027,7 +3140,8 @@ func TestDedicatedServerDeleteDhcpReservationServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.DeleteDhcpReservation("12345")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.DeleteDhcpReservation(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3044,7 +3158,8 @@ func TestDedicatedServerDeleteDhcpReservationServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.DeleteDhcpReservation("12345")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.DeleteDhcpReservation(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3061,7 +3176,8 @@ func TestDedicatedServerDeleteDhcpReservationServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.DeleteDhcpReservation("12345")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.DeleteDhcpReservation(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3078,7 +3194,8 @@ func TestDedicatedServerDeleteDhcpReservationServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.DeleteDhcpReservation("12345")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.DeleteDhcpReservation(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3095,7 +3212,8 @@ func TestDedicatedServerDeleteDhcpReservationServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.DeleteDhcpReservation("12345")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.DeleteDhcpReservation(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3116,7 +3234,8 @@ func TestDedicatedServerCreateDhcpReservation(t *testing.T) {
 	defer teardown()
 
 	payload := map[string]string{"bootfile": "http://example.com/bootme.ipxe", "hostname": "my-server"}
-	err := DedicatedServerApi{}.CreateDhcpReservation("12345", payload)
+	ctx := context.Background()
+	err := DedicatedServerApi{}.CreateDhcpReservation(ctx, "12345", payload)
 	assert := assert.New(t)
 	assert.Nil(err)
 }
@@ -3133,7 +3252,8 @@ func TestDedicatedServerCreateDhcpReservationServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"bootfile": "http://example.com/bootme.ipxe", "hostname": "my-server"}
-				return nil, DedicatedServerApi{}.CreateDhcpReservation("12345", payload)
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.CreateDhcpReservation(ctx, "12345", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3151,7 +3271,8 @@ func TestDedicatedServerCreateDhcpReservationServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"bootfile": "http://example.com/bootme.ipxe", "hostname": "my-server"}
-				return nil, DedicatedServerApi{}.CreateDhcpReservation("12345", payload)
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.CreateDhcpReservation(ctx, "12345", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3169,7 +3290,8 @@ func TestDedicatedServerCreateDhcpReservationServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"bootfile": "http://example.com/bootme.ipxe", "hostname": "my-server"}
-				return nil, DedicatedServerApi{}.CreateDhcpReservation("12345", payload)
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.CreateDhcpReservation(ctx, "12345", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3187,7 +3309,8 @@ func TestDedicatedServerCreateDhcpReservationServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"bootfile": "http://example.com/bootme.ipxe", "hostname": "my-server"}
-				return nil, DedicatedServerApi{}.CreateDhcpReservation("12345", payload)
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.CreateDhcpReservation(ctx, "12345", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3205,7 +3328,8 @@ func TestDedicatedServerCreateDhcpReservationServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"bootfile": "http://example.com/bootme.ipxe", "hostname": "my-server"}
-				return nil, DedicatedServerApi{}.CreateDhcpReservation("12345", payload)
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.CreateDhcpReservation(ctx, "12345", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3249,7 +3373,8 @@ func TestDedicatedServerListDhcpReservation(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedServerApi{}.ListDhcpReservation("server-id")
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.ListDhcpReservation(ctx, "server-id")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 1)
@@ -3279,7 +3404,8 @@ func TestDedicatedServerListDhcpReservationBeEmpty(t *testing.T) {
 		fmt.Fprintf(w, `{"_metadata":{"limit": 10, "offset": 0, "totalCount": 0}, "leases": []}`)
 	})
 	defer teardown()
-	response, err := DedicatedServerApi{}.ListDhcpReservation("server-id")
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.ListDhcpReservation(ctx, "server-id")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 0)
@@ -3320,7 +3446,8 @@ func TestDedicatedServerListDhcpReservationPagination(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedServerApi{}.ListDhcpReservation("server-id", 1)
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.ListDhcpReservation(ctx, "server-id", 1)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 11)
@@ -3354,7 +3481,8 @@ func TestDedicatedServerListDhcpReservationServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListDhcpReservation("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListDhcpReservation(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3371,7 +3499,8 @@ func TestDedicatedServerListDhcpReservationServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListDhcpReservation("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListDhcpReservation(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3388,7 +3517,8 @@ func TestDedicatedServerListDhcpReservationServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListDhcpReservation("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListDhcpReservation(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3405,7 +3535,8 @@ func TestDedicatedServerListDhcpReservationServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListDhcpReservation("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListDhcpReservation(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3488,7 +3619,8 @@ func TestDedicatedServerCancelActiveJob(t *testing.T) {
 	})
 	defer teardown()
 
-	Job, err := DedicatedServerApi{}.CancelActiveJob("12345")
+	ctx := context.Background()
+	Job, err := DedicatedServerApi{}.CancelActiveJob(ctx, "12345")
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -3554,7 +3686,8 @@ func TestDedicatedServerCancelActiveJobServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.CancelActiveJob("12345")
+				ctx := context.Background()
+				return DedicatedServerApi{}.CancelActiveJob(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3571,7 +3704,8 @@ func TestDedicatedServerCancelActiveJobServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.CancelActiveJob("12345")
+				ctx := context.Background()
+				return DedicatedServerApi{}.CancelActiveJob(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3588,7 +3722,8 @@ func TestDedicatedServerCancelActiveJobServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.CancelActiveJob("12345")
+				ctx := context.Background()
+				return DedicatedServerApi{}.CancelActiveJob(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3605,7 +3740,8 @@ func TestDedicatedServerCancelActiveJobServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.CancelActiveJob("12345")
+				ctx := context.Background()
+				return DedicatedServerApi{}.CancelActiveJob(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3622,7 +3758,8 @@ func TestDedicatedServerCancelActiveJobServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.CancelActiveJob("12345")
+				ctx := context.Background()
+				return DedicatedServerApi{}.CancelActiveJob(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3705,7 +3842,8 @@ func TestDedicatedServerExpireActiveJob(t *testing.T) {
 	})
 	defer teardown()
 
-	Job, err := DedicatedServerApi{}.ExpireActiveJob("12345")
+	ctx := context.Background()
+	Job, err := DedicatedServerApi{}.ExpireActiveJob(ctx, "12345")
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -3771,7 +3909,8 @@ func TestDedicatedServerExpireActiveJobServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ExpireActiveJob("12345")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ExpireActiveJob(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3788,7 +3927,8 @@ func TestDedicatedServerExpireActiveJobServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ExpireActiveJob("12345")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ExpireActiveJob(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3805,7 +3945,8 @@ func TestDedicatedServerExpireActiveJobServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ExpireActiveJob("12345")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ExpireActiveJob(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3822,7 +3963,8 @@ func TestDedicatedServerExpireActiveJobServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ExpireActiveJob("12345")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ExpireActiveJob(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3839,7 +3981,8 @@ func TestDedicatedServerExpireActiveJobServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ExpireActiveJob("12345")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ExpireActiveJob(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3902,7 +4045,8 @@ func TestDedicatedServerLaunchHardwareScan(t *testing.T) {
 	defer teardown()
 
 	payload := map[string]interface{}{"callbackUrl": "http://callback.url", "powerCycle": true}
-	Job, err := DedicatedServerApi{}.LaunchHardwareScan("12345", payload)
+	ctx := context.Background()
+	Job, err := DedicatedServerApi{}.LaunchHardwareScan(ctx, "12345", payload)
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -3954,7 +4098,8 @@ func TestDedicatedServerLaunchHardwareScanServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]interface{}{"callbackUrl": "http://callback.url", "powerCycle": true}
-				return DedicatedServerApi{}.LaunchHardwareScan("12345", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.LaunchHardwareScan(ctx, "12345", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3972,7 +4117,8 @@ func TestDedicatedServerLaunchHardwareScanServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]interface{}{"callbackUrl": "http://callback.url", "powerCycle": true}
-				return DedicatedServerApi{}.LaunchHardwareScan("12345", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.LaunchHardwareScan(ctx, "12345", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3990,7 +4136,8 @@ func TestDedicatedServerLaunchHardwareScanServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]interface{}{"callbackUrl": "http://callback.url", "powerCycle": true}
-				return DedicatedServerApi{}.LaunchHardwareScan("12345", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.LaunchHardwareScan(ctx, "12345", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4008,7 +4155,8 @@ func TestDedicatedServerLaunchHardwareScanServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]interface{}{"callbackUrl": "http://callback.url", "powerCycle": true}
-				return DedicatedServerApi{}.LaunchHardwareScan("12345", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.LaunchHardwareScan(ctx, "12345", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4026,7 +4174,8 @@ func TestDedicatedServerLaunchHardwareScanServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]interface{}{"callbackUrl": "http://callback.url", "powerCycle": true}
-				return DedicatedServerApi{}.LaunchHardwareScan("12345", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.LaunchHardwareScan(ctx, "12345", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4157,7 +4306,8 @@ func TestDedicatedServerLaunchInstallation(t *testing.T) {
 		},
 		"sshKeys": "ssh-rsa AAAAB3NzaC1y... user@domain.com",
 	}
-	Job, err := DedicatedServerApi{}.LaunchInstallation("12345", payload)
+	ctx := context.Background()
+	Job, err := DedicatedServerApi{}.LaunchInstallation(ctx, "12345", payload)
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -4266,7 +4416,8 @@ func TestDedicatedServerLaunchInstallationServerErrors(t *testing.T) {
 					},
 					"sshKeys": "ssh-rsa AAAAB3NzaC1y... user@domain.com",
 				}
-				return DedicatedServerApi{}.LaunchInstallation("12345", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.LaunchInstallation(ctx, "12345", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4314,7 +4465,8 @@ func TestDedicatedServerLaunchInstallationServerErrors(t *testing.T) {
 					},
 					"sshKeys": "ssh-rsa AAAAB3NzaC1y... user@domain.com",
 				}
-				return DedicatedServerApi{}.LaunchInstallation("12345", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.LaunchInstallation(ctx, "12345", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4362,7 +4514,8 @@ func TestDedicatedServerLaunchInstallationServerErrors(t *testing.T) {
 					},
 					"sshKeys": "ssh-rsa AAAAB3NzaC1y... user@domain.com",
 				}
-				return DedicatedServerApi{}.LaunchInstallation("12345", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.LaunchInstallation(ctx, "12345", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4410,7 +4563,8 @@ func TestDedicatedServerLaunchInstallationServerErrors(t *testing.T) {
 					},
 					"sshKeys": "ssh-rsa AAAAB3NzaC1y... user@domain.com",
 				}
-				return DedicatedServerApi{}.LaunchInstallation("12345", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.LaunchInstallation(ctx, "12345", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4458,7 +4612,8 @@ func TestDedicatedServerLaunchInstallationServerErrors(t *testing.T) {
 					},
 					"sshKeys": "ssh-rsa AAAAB3NzaC1y... user@domain.com",
 				}
-				return DedicatedServerApi{}.LaunchInstallation("12345", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.LaunchInstallation(ctx, "12345", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4522,7 +4677,8 @@ func TestDedicatedServerLaunchIpmiRest(t *testing.T) {
 	defer teardown()
 
 	payload := map[string]interface{}{"callbackUrl": "https://callbacks.example.org"}
-	Job, err := DedicatedServerApi{}.LaunchIpmiRest("12345", payload)
+	ctx := context.Background()
+	Job, err := DedicatedServerApi{}.LaunchIpmiRest(ctx, "12345", payload)
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -4577,7 +4733,8 @@ func TestDedicatedServerLaunchIpmiRestServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]interface{}{"callbackUrl": "https://callbacks.example.org"}
-				return DedicatedServerApi{}.LaunchIpmiRest("12345", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.LaunchIpmiRest(ctx, "12345", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4595,7 +4752,8 @@ func TestDedicatedServerLaunchIpmiRestServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]interface{}{"callbackUrl": "https://callbacks.example.org"}
-				return DedicatedServerApi{}.LaunchIpmiRest("12345", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.LaunchIpmiRest(ctx, "12345", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4613,7 +4771,8 @@ func TestDedicatedServerLaunchIpmiRestServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]interface{}{"callbackUrl": "https://callbacks.example.org"}
-				return DedicatedServerApi{}.LaunchIpmiRest("12345", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.LaunchIpmiRest(ctx, "12345", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4631,7 +4790,8 @@ func TestDedicatedServerLaunchIpmiRestServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]interface{}{"callbackUrl": "https://callbacks.example.org"}
-				return DedicatedServerApi{}.LaunchIpmiRest("12345", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.LaunchIpmiRest(ctx, "12345", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4649,7 +4809,8 @@ func TestDedicatedServerLaunchIpmiRestServerErrors(t *testing.T) {
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]interface{}{"callbackUrl": "https://callbacks.example.org"}
-				return DedicatedServerApi{}.LaunchIpmiRest("12345", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.LaunchIpmiRest(ctx, "12345", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4699,7 +4860,8 @@ func TestDedicatedServerListJobs(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedServerApi{}.ListJobs("99944")
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.ListJobs(ctx, "99944")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 1)
@@ -4735,7 +4897,8 @@ func TestDedicatedServerListJobsBeEmpty(t *testing.T) {
 		fmt.Fprintf(w, `{"_metadata":{"limit": 10, "offset": 0, "totalCount": 0}, "jobs": []}`)
 	})
 	defer teardown()
-	response, err := DedicatedServerApi{}.ListJobs("99944")
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.ListJobs(ctx, "99944")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 0)
@@ -4782,7 +4945,8 @@ func TestDedicatedServerListJobsPaginate(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedServerApi{}.ListJobs("99944", 1)
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.ListJobs(ctx, "99944", 1)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 11)
@@ -4822,7 +4986,8 @@ func TestDedicatedServerListJobsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListJobs("99944")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListJobs(ctx, "99944")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4839,7 +5004,8 @@ func TestDedicatedServerListJobsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListJobs("99944")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListJobs(ctx, "99944")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4856,7 +5022,8 @@ func TestDedicatedServerListJobsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListJobs("99944")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListJobs(ctx, "99944")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4873,7 +5040,8 @@ func TestDedicatedServerListJobsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListJobs("99944")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListJobs(ctx, "99944")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4958,7 +5126,8 @@ func TestDedicatedServerGetJob(t *testing.T) {
 	})
 	defer teardown()
 
-	Job, err := DedicatedServerApi{}.GetJob("99944", "job id")
+	ctx := context.Background()
+	Job, err := DedicatedServerApi{}.GetJob(ctx, "99944", "job id")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(Job.Progress.Canceled.String(), "0")
@@ -5022,7 +5191,8 @@ func TestDedicatedServerGetJobServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetJob("99944", "job id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetJob(ctx, "99944", "job id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5039,7 +5209,8 @@ func TestDedicatedServerGetJobServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetJob("99944", "job id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetJob(ctx, "99944", "job id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5056,7 +5227,8 @@ func TestDedicatedServerGetJobServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetJob("99944", "job id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetJob(ctx, "99944", "job id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5073,7 +5245,8 @@ func TestDedicatedServerGetJobServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetJob("99944", "job id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetJob(ctx, "99944", "job id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5090,7 +5263,8 @@ func TestDedicatedServerGetJobServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetJob("99944", "job id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetJob(ctx, "99944", "job id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5159,7 +5333,8 @@ func TestDedicatedServerLaunchRescueMode(t *testing.T) {
 		"rescueImageId": "GRML",
 		"sshKeys":       "ssh-rsa AAAAB3NzaC1y... user@domain.com",
 	}
-	Job, err := DedicatedServerApi{}.LaunchRescueMode("2349839", payload)
+	ctx := context.Background()
+	Job, err := DedicatedServerApi{}.LaunchRescueMode(ctx, "2349839", payload)
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -5219,7 +5394,8 @@ func TestDedicatedServerLaunchRescueModeServerErrors(t *testing.T) {
 					"rescueImageId": "GRML",
 					"sshKeys":       "ssh-rsa AAAAB3NzaC1y... user@domain.com",
 				}
-				return DedicatedServerApi{}.LaunchRescueMode("2349839", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.LaunchRescueMode(ctx, "2349839", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5242,7 +5418,8 @@ func TestDedicatedServerLaunchRescueModeServerErrors(t *testing.T) {
 					"rescueImageId": "GRML",
 					"sshKeys":       "ssh-rsa AAAAB3NzaC1y... user@domain.com",
 				}
-				return DedicatedServerApi{}.LaunchRescueMode("2349839", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.LaunchRescueMode(ctx, "2349839", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5265,7 +5442,8 @@ func TestDedicatedServerLaunchRescueModeServerErrors(t *testing.T) {
 					"rescueImageId": "GRML",
 					"sshKeys":       "ssh-rsa AAAAB3NzaC1y... user@domain.com",
 				}
-				return DedicatedServerApi{}.LaunchRescueMode("2349839", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.LaunchRescueMode(ctx, "2349839", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5288,7 +5466,8 @@ func TestDedicatedServerLaunchRescueModeServerErrors(t *testing.T) {
 					"rescueImageId": "GRML",
 					"sshKeys":       "ssh-rsa AAAAB3NzaC1y... user@domain.com",
 				}
-				return DedicatedServerApi{}.LaunchRescueMode("2349839", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.LaunchRescueMode(ctx, "2349839", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5311,7 +5490,8 @@ func TestDedicatedServerLaunchRescueModeServerErrors(t *testing.T) {
 					"rescueImageId": "GRML",
 					"sshKeys":       "ssh-rsa AAAAB3NzaC1y... user@domain.com",
 				}
-				return DedicatedServerApi{}.LaunchRescueMode("2349839", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.LaunchRescueMode(ctx, "2349839", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5355,7 +5535,8 @@ func TestDedicatedServerListCredentials(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedServerApi{}.ListCredentials("99944")
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.ListCredentials(ctx, "99944")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 4)
@@ -5380,7 +5561,8 @@ func TestDedicatedServerListCredentialsBeEmpty(t *testing.T) {
 		fmt.Fprintf(w, `{"_metadata":{"limit": 10, "offset": 0, "totalCount": 0}, "credentials": []}`)
 	})
 	defer teardown()
-	response, err := DedicatedServerApi{}.ListCredentials("99944")
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.ListCredentials(ctx, "99944")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 0)
@@ -5409,7 +5591,8 @@ func TestDedicatedServerListCredentialsPaginate(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedServerApi{}.ListCredentials("99944")
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.ListCredentials(ctx, "99944")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 11)
@@ -5432,7 +5615,8 @@ func TestDedicatedServerListCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListCredentials("99944")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListCredentials(ctx, "99944")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5449,7 +5633,8 @@ func TestDedicatedServerListCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListCredentials("99944")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListCredentials(ctx, "99944")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5466,7 +5651,8 @@ func TestDedicatedServerListCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListCredentials("99944")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListCredentials(ctx, "99944")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5483,7 +5669,8 @@ func TestDedicatedServerListCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListCredentials("99944")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListCredentials(ctx, "99944")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5500,7 +5687,8 @@ func TestDedicatedServerListCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListCredentials("99944")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListCredentials(ctx, "99944")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5524,7 +5712,8 @@ func TestDedicatedServerCreateCredential(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := DedicatedServerApi{}.CreateCredential("12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
+	ctx := context.Background()
+	resp, err := DedicatedServerApi{}.CreateCredential(ctx, "12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -5544,7 +5733,8 @@ func TestDedicatedServerCreateCredentialServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"430495b4-c052-451a-a016-30d8f72ac59b","errorCode":"400","errorMessage":"Validation Failed","errorDetails":{"username":["Usernames can only contain alphanumeric values and @.-_ characters"],"password":["This field is missing."]}}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.CreateCredential("12345", "OPERATING_SYSTEM", "ro=ot", "")
+				ctx := context.Background()
+				return DedicatedServerApi{}.CreateCredential(ctx, "12345", "OPERATING_SYSTEM", "ro=ot", "")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "430495b4-c052-451a-a016-30d8f72ac59b",
@@ -5565,7 +5755,8 @@ func TestDedicatedServerCreateCredentialServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.CreateCredential("12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
+				ctx := context.Background()
+				return DedicatedServerApi{}.CreateCredential(ctx, "12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5582,7 +5773,8 @@ func TestDedicatedServerCreateCredentialServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.CreateCredential("12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
+				ctx := context.Background()
+				return DedicatedServerApi{}.CreateCredential(ctx, "12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5599,7 +5791,8 @@ func TestDedicatedServerCreateCredentialServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.CreateCredential("12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
+				ctx := context.Background()
+				return DedicatedServerApi{}.CreateCredential(ctx, "12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5616,7 +5809,8 @@ func TestDedicatedServerCreateCredentialServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.CreateCredential("12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
+				ctx := context.Background()
+				return DedicatedServerApi{}.CreateCredential(ctx, "12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5633,7 +5827,8 @@ func TestDedicatedServerCreateCredentialServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.CreateCredential("12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
+				ctx := context.Background()
+				return DedicatedServerApi{}.CreateCredential(ctx, "12345", "OPERATING_SYSTEM", "root", "mys3cr3tp@ssw0rd")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5669,7 +5864,8 @@ func TestDedicatedServerListCredentialsByType(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedServerApi{}.ListCredentialsByType("99944", "REMOTE_MANAGEMENT")
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.ListCredentialsByType(ctx, "99944", "REMOTE_MANAGEMENT")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 2)
@@ -5690,7 +5886,8 @@ func TestDedicatedServerListCredentialsByTypeBeEmpty(t *testing.T) {
 		fmt.Fprintf(w, `{"_metadata":{"limit": 10, "offset": 0, "totalCount": 0}, "credentials": []}`)
 	})
 	defer teardown()
-	response, err := DedicatedServerApi{}.ListCredentialsByType("99944", "REMOTE_MANAGEMENT")
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.ListCredentialsByType(ctx, "99944", "REMOTE_MANAGEMENT")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 0)
@@ -5719,7 +5916,8 @@ func TestDedicatedServerListCredentialsByTypePaginate(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedServerApi{}.ListCredentialsByType("99944", "REMOTE_MANAGEMENT")
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.ListCredentialsByType(ctx, "99944", "REMOTE_MANAGEMENT")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 11)
@@ -5742,7 +5940,8 @@ func TestDedicatedServerListCredentialsByTypeServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListCredentialsByType("99944", "REMOTE_MANAGEMENT")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListCredentialsByType(ctx, "99944", "REMOTE_MANAGEMENT")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5759,7 +5958,8 @@ func TestDedicatedServerListCredentialsByTypeServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListCredentialsByType("99944", "REMOTE_MANAGEMENT")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListCredentialsByType(ctx, "99944", "REMOTE_MANAGEMENT")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5776,7 +5976,8 @@ func TestDedicatedServerListCredentialsByTypeServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListCredentialsByType("99944", "REMOTE_MANAGEMENT")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListCredentialsByType(ctx, "99944", "REMOTE_MANAGEMENT")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5793,7 +5994,8 @@ func TestDedicatedServerListCredentialsByTypeServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListCredentialsByType("99944", "REMOTE_MANAGEMENT")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListCredentialsByType(ctx, "99944", "REMOTE_MANAGEMENT")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5810,7 +6012,8 @@ func TestDedicatedServerListCredentialsByTypeServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListCredentialsByType("99944", "REMOTE_MANAGEMENT")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListCredentialsByType(ctx, "99944", "REMOTE_MANAGEMENT")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5834,7 +6037,8 @@ func TestDedicatedServerGetCredentials(t *testing.T) {
 	})
 	defer teardown()
 
-	Credential, err := DedicatedServerApi{}.GetCredential("12345", "OPERATING_SYSTEM", "root")
+	ctx := context.Background()
+	Credential, err := DedicatedServerApi{}.GetCredential(ctx, "12345", "OPERATING_SYSTEM", "root")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(Credential.Password, "mys3cr3tp@ssw0rd")
@@ -5853,7 +6057,8 @@ func TestDedicatedServerGetCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetCredential("12345", "OPERATING_SYSTEM", "root")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetCredential(ctx, "12345", "OPERATING_SYSTEM", "root")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5870,7 +6075,8 @@ func TestDedicatedServerGetCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetCredential("12345", "OPERATING_SYSTEM", "root")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetCredential(ctx, "12345", "OPERATING_SYSTEM", "root")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5887,7 +6093,8 @@ func TestDedicatedServerGetCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetCredential("12345", "OPERATING_SYSTEM", "root")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetCredential(ctx, "12345", "OPERATING_SYSTEM", "root")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5904,7 +6111,8 @@ func TestDedicatedServerGetCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetCredential("12345", "OPERATING_SYSTEM", "root")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetCredential(ctx, "12345", "OPERATING_SYSTEM", "root")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5921,7 +6129,8 @@ func TestDedicatedServerGetCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetCredential("12345", "OPERATING_SYSTEM", "root")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetCredential(ctx, "12345", "OPERATING_SYSTEM", "root")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5941,7 +6150,8 @@ func TestDedicatedServerDeleteCredentials(t *testing.T) {
 	})
 	defer teardown()
 
-	err := DedicatedServerApi{}.DeleteCredential("12345", "OPERATING_SYSTEM", "admin")
+	ctx := context.Background()
+	err := DedicatedServerApi{}.DeleteCredential(ctx, "12345", "OPERATING_SYSTEM", "admin")
 	assert := assert.New(t)
 	assert.Nil(err)
 }
@@ -5957,7 +6167,8 @@ func TestDedicatedServerDeleteCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.DeleteCredential("12345", "OPERATING_SYSTEM", "admin")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.DeleteCredential(ctx, "12345", "OPERATING_SYSTEM", "admin")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5974,7 +6185,8 @@ func TestDedicatedServerDeleteCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.DeleteCredential("12345", "OPERATING_SYSTEM", "admin")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.DeleteCredential(ctx, "12345", "OPERATING_SYSTEM", "admin")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -5991,7 +6203,8 @@ func TestDedicatedServerDeleteCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.DeleteCredential("12345", "OPERATING_SYSTEM", "admin")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.DeleteCredential(ctx, "12345", "OPERATING_SYSTEM", "admin")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6008,7 +6221,8 @@ func TestDedicatedServerDeleteCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.DeleteCredential("12345", "OPERATING_SYSTEM", "admin")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.DeleteCredential(ctx, "12345", "OPERATING_SYSTEM", "admin")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6025,7 +6239,8 @@ func TestDedicatedServerDeleteCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.DeleteCredential("12345", "OPERATING_SYSTEM", "admin")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.DeleteCredential(ctx, "12345", "OPERATING_SYSTEM", "admin")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6049,7 +6264,8 @@ func TestDedicatedServerUpdateCredentials(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := DedicatedServerApi{}.UpdateCredential("12345", "OPERATING_SYSTEM", "admin", "new password")
+	ctx := context.Background()
+	resp, err := DedicatedServerApi{}.UpdateCredential(ctx, "12345", "OPERATING_SYSTEM", "admin", "new password")
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -6069,7 +6285,8 @@ func TestDedicatedServerUpdateCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.UpdateCredential("12345", "OPERATING_SYSTEM", "admin", "new password")
+				ctx := context.Background()
+				return DedicatedServerApi{}.UpdateCredential(ctx, "12345", "OPERATING_SYSTEM", "admin", "new password")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6086,7 +6303,8 @@ func TestDedicatedServerUpdateCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.UpdateCredential("12345", "OPERATING_SYSTEM", "admin", "new password")
+				ctx := context.Background()
+				return DedicatedServerApi{}.UpdateCredential(ctx, "12345", "OPERATING_SYSTEM", "admin", "new password")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6103,7 +6321,8 @@ func TestDedicatedServerUpdateCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.UpdateCredential("12345", "OPERATING_SYSTEM", "admin", "new password")
+				ctx := context.Background()
+				return DedicatedServerApi{}.UpdateCredential(ctx, "12345", "OPERATING_SYSTEM", "admin", "new password")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6120,7 +6339,8 @@ func TestDedicatedServerUpdateCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.UpdateCredential("12345", "OPERATING_SYSTEM", "admin", "new password")
+				ctx := context.Background()
+				return DedicatedServerApi{}.UpdateCredential(ctx, "12345", "OPERATING_SYSTEM", "admin", "new password")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6137,7 +6357,8 @@ func TestDedicatedServerUpdateCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.UpdateCredential("12345", "OPERATING_SYSTEM", "admin", "new password")
+				ctx := context.Background()
+				return DedicatedServerApi{}.UpdateCredential(ctx, "12345", "OPERATING_SYSTEM", "admin", "new password")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6192,7 +6413,8 @@ func TestDedicatedServerGetBandWidthMetrics(t *testing.T) {
 	})
 	defer teardown()
 
-	Metric, err := DedicatedServerApi{}.GetBandWidthMetrics("99944", "HOUR", "AVG", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+	ctx := context.Background()
+	Metric, err := DedicatedServerApi{}.GetBandWidthMetrics(ctx, "99944", "HOUR", "AVG", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(Metric.Metadata.Aggregation, "AVG")
@@ -6223,7 +6445,8 @@ func TestDedicatedServerGetBandWidthMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetBandWidthMetrics("99944", "HOUR", "AVG", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetBandWidthMetrics(ctx, "99944", "HOUR", "AVG", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6240,7 +6463,8 @@ func TestDedicatedServerGetBandWidthMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetBandWidthMetrics("99944", "HOUR", "AVG", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetBandWidthMetrics(ctx, "99944", "HOUR", "AVG", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6257,7 +6481,8 @@ func TestDedicatedServerGetBandWidthMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetBandWidthMetrics("99944", "HOUR", "AVG", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetBandWidthMetrics(ctx, "99944", "HOUR", "AVG", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6274,7 +6499,8 @@ func TestDedicatedServerGetBandWidthMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetBandWidthMetrics("99944", "HOUR", "AVG", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetBandWidthMetrics(ctx, "99944", "HOUR", "AVG", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6291,7 +6517,8 @@ func TestDedicatedServerGetBandWidthMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetBandWidthMetrics("99944", "HOUR", "AVG", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetBandWidthMetrics(ctx, "99944", "HOUR", "AVG", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6346,7 +6573,8 @@ func TestDedicatedServerGetDataTrafficMetrics(t *testing.T) {
 	})
 	defer teardown()
 
-	Metric, err := DedicatedServerApi{}.GetDataTrafficMetrics("99944", "HOUR", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+	ctx := context.Background()
+	Metric, err := DedicatedServerApi{}.GetDataTrafficMetrics(ctx, "99944", "HOUR", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(Metric.Metadata.Aggregation, "SUM")
@@ -6377,7 +6605,8 @@ func TestDedicatedServerGetDataTrafficMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetDataTrafficMetrics("99944", "HOUR", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetDataTrafficMetrics(ctx, "99944", "HOUR", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6394,7 +6623,8 @@ func TestDedicatedServerGetDataTrafficMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetDataTrafficMetrics("99944", "HOUR", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetDataTrafficMetrics(ctx, "99944", "HOUR", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6411,7 +6641,8 @@ func TestDedicatedServerGetDataTrafficMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetDataTrafficMetrics("99944", "HOUR", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetDataTrafficMetrics(ctx, "99944", "HOUR", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6428,7 +6659,8 @@ func TestDedicatedServerGetDataTrafficMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetDataTrafficMetrics("99944", "HOUR", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetDataTrafficMetrics(ctx, "99944", "HOUR", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6445,7 +6677,8 @@ func TestDedicatedServerGetDataTrafficMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetDataTrafficMetrics("99944", "HOUR", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetDataTrafficMetrics(ctx, "99944", "HOUR", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6501,7 +6734,8 @@ func TestDedicatedServerListBandWidthNotificationSettings(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := DedicatedServerApi{}.ListBandWidthNotificationSettings("server-id")
+	ctx := context.Background()
+	resp, err := DedicatedServerApi{}.ListBandWidthNotificationSettings(ctx, "server-id")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(resp.Metadata.TotalCount, 2)
@@ -6558,7 +6792,8 @@ func TestDedicatedServerListBandWidthNotificationSettingsPaginate(t *testing.T) 
 	})
 	defer teardown()
 
-	resp, err := DedicatedServerApi{}.ListBandWidthNotificationSettings("server-id", 1)
+	ctx := context.Background()
+	resp, err := DedicatedServerApi{}.ListBandWidthNotificationSettings(ctx, "server-id", 1)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(resp.Metadata.TotalCount, 11)
@@ -6587,7 +6822,8 @@ func TestDedicatedServerListBandWidthNotificationSettingsServerErrors(t *testing
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListBandWidthNotificationSettings("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListBandWidthNotificationSettings(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6604,7 +6840,8 @@ func TestDedicatedServerListBandWidthNotificationSettingsServerErrors(t *testing
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListBandWidthNotificationSettings("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListBandWidthNotificationSettings(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6621,7 +6858,8 @@ func TestDedicatedServerListBandWidthNotificationSettingsServerErrors(t *testing
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListBandWidthNotificationSettings("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListBandWidthNotificationSettings(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6638,7 +6876,8 @@ func TestDedicatedServerListBandWidthNotificationSettingsServerErrors(t *testing
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListBandWidthNotificationSettings("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListBandWidthNotificationSettings(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6655,7 +6894,8 @@ func TestDedicatedServerListBandWidthNotificationSettingsServerErrors(t *testing
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListBandWidthNotificationSettings("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListBandWidthNotificationSettings(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6688,7 +6928,8 @@ func TestDedicatedServerCreateBandWidthNotificationSetting(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := DedicatedServerApi{}.CreateBandWidthNotificationSetting("server-id", "WEEKLY", "1", "Gbps")
+	ctx := context.Background()
+	resp, err := DedicatedServerApi{}.CreateBandWidthNotificationSetting(ctx, "server-id", "WEEKLY", "1", "Gbps")
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -6713,7 +6954,8 @@ func TestDedicatedServerCreateBandWidthNotificationSettingServerErrors(t *testin
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.CreateBandWidthNotificationSetting("server-id", "WEEKLY", "1", "Gbps")
+				ctx := context.Background()
+				return DedicatedServerApi{}.CreateBandWidthNotificationSetting(ctx, "server-id", "WEEKLY", "1", "Gbps")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6730,7 +6972,8 @@ func TestDedicatedServerCreateBandWidthNotificationSettingServerErrors(t *testin
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.CreateBandWidthNotificationSetting("server-id", "WEEKLY", "1", "Gbps")
+				ctx := context.Background()
+				return DedicatedServerApi{}.CreateBandWidthNotificationSetting(ctx, "server-id", "WEEKLY", "1", "Gbps")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6747,7 +6990,8 @@ func TestDedicatedServerCreateBandWidthNotificationSettingServerErrors(t *testin
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.CreateBandWidthNotificationSetting("server-id", "WEEKLY", "1", "Gbps")
+				ctx := context.Background()
+				return DedicatedServerApi{}.CreateBandWidthNotificationSetting(ctx, "server-id", "WEEKLY", "1", "Gbps")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6764,7 +7008,8 @@ func TestDedicatedServerCreateBandWidthNotificationSettingServerErrors(t *testin
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.CreateBandWidthNotificationSetting("server-id", "WEEKLY", "1", "Gbps")
+				ctx := context.Background()
+				return DedicatedServerApi{}.CreateBandWidthNotificationSetting(ctx, "server-id", "WEEKLY", "1", "Gbps")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6781,7 +7026,8 @@ func TestDedicatedServerCreateBandWidthNotificationSettingServerErrors(t *testin
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.CreateBandWidthNotificationSetting("server-id", "WEEKLY", "1", "Gbps")
+				ctx := context.Background()
+				return DedicatedServerApi{}.CreateBandWidthNotificationSetting(ctx, "server-id", "WEEKLY", "1", "Gbps")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6801,7 +7047,8 @@ func TestDedicatedServerDeleteBandWidthNotificationSetting(t *testing.T) {
 	})
 	defer teardown()
 
-	err := DedicatedServerApi{}.DeleteBandWidthNotificationSetting("server id", "notification id")
+	ctx := context.Background()
+	err := DedicatedServerApi{}.DeleteBandWidthNotificationSetting(ctx, "server id", "notification id")
 	assert := assert.New(t)
 	assert.Nil(err)
 }
@@ -6817,7 +7064,8 @@ func TestDedicatedServerDeleteBandWidthNotificationSettingServerErrors(t *testin
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.DeleteBandWidthNotificationSetting("server id", "notification id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.DeleteBandWidthNotificationSetting(ctx, "server id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6834,7 +7082,8 @@ func TestDedicatedServerDeleteBandWidthNotificationSettingServerErrors(t *testin
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.DeleteBandWidthNotificationSetting("server id", "notification id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.DeleteBandWidthNotificationSetting(ctx, "server id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6851,7 +7100,8 @@ func TestDedicatedServerDeleteBandWidthNotificationSettingServerErrors(t *testin
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.DeleteBandWidthNotificationSetting("server id", "notification id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.DeleteBandWidthNotificationSetting(ctx, "server id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6868,7 +7118,8 @@ func TestDedicatedServerDeleteBandWidthNotificationSettingServerErrors(t *testin
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.DeleteBandWidthNotificationSetting("server id", "notification id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.DeleteBandWidthNotificationSetting(ctx, "server id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6885,7 +7136,8 @@ func TestDedicatedServerDeleteBandWidthNotificationSettingServerErrors(t *testin
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.DeleteBandWidthNotificationSetting("server id", "notification id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.DeleteBandWidthNotificationSetting(ctx, "server id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6918,7 +7170,8 @@ func TestDedicatedServerGetBandWidthNotificationSetting(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := DedicatedServerApi{}.GetBandWidthNotificationSetting("server-id", "notification id")
+	ctx := context.Background()
+	resp, err := DedicatedServerApi{}.GetBandWidthNotificationSetting(ctx, "server-id", "notification id")
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -6943,7 +7196,8 @@ func TestDedicatedServerGetBandWidthNotificationSettingServerErrors(t *testing.T
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetBandWidthNotificationSetting("server-id", "notification id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetBandWidthNotificationSetting(ctx, "server-id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6960,7 +7214,8 @@ func TestDedicatedServerGetBandWidthNotificationSettingServerErrors(t *testing.T
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetBandWidthNotificationSetting("server-id", "notification id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetBandWidthNotificationSetting(ctx, "server-id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6977,7 +7232,8 @@ func TestDedicatedServerGetBandWidthNotificationSettingServerErrors(t *testing.T
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetBandWidthNotificationSetting("server-id", "notification id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetBandWidthNotificationSetting(ctx, "server-id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -6994,7 +7250,8 @@ func TestDedicatedServerGetBandWidthNotificationSettingServerErrors(t *testing.T
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetBandWidthNotificationSetting("server-id", "notification id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetBandWidthNotificationSetting(ctx, "server-id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7011,7 +7268,8 @@ func TestDedicatedServerGetBandWidthNotificationSettingServerErrors(t *testing.T
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetBandWidthNotificationSetting("server-id", "notification id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetBandWidthNotificationSetting(ctx, "server-id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7045,7 +7303,8 @@ func TestDedicatedServerUpdateBandWidthNotificationSetting(t *testing.T) {
 	defer teardown()
 
 	payload := map[string]string{"frequency": "MONTHLY", "threshold": "2", "unit": "Mbps"}
-	resp, err := DedicatedServerApi{}.UpdateBandWidthNotificationSetting("server-id", "notification id", payload)
+	ctx := context.Background()
+	resp, err := DedicatedServerApi{}.UpdateBandWidthNotificationSetting(ctx, "server-id", "notification id", payload)
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -7071,7 +7330,8 @@ func TestDedicatedServerUpdateBandWidthNotificationSettingServerErrors(t *testin
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"frequency": "MONTHLY", "threshold": "2", "unit": "Mbps"}
-				return DedicatedServerApi{}.UpdateBandWidthNotificationSetting("server-id", "notification id", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.UpdateBandWidthNotificationSetting(ctx, "server-id", "notification id", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7089,7 +7349,8 @@ func TestDedicatedServerUpdateBandWidthNotificationSettingServerErrors(t *testin
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"frequency": "MONTHLY", "threshold": "2", "unit": "Mbps"}
-				return DedicatedServerApi{}.UpdateBandWidthNotificationSetting("server-id", "notification id", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.UpdateBandWidthNotificationSetting(ctx, "server-id", "notification id", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7107,7 +7368,8 @@ func TestDedicatedServerUpdateBandWidthNotificationSettingServerErrors(t *testin
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"frequency": "MONTHLY", "threshold": "2", "unit": "Mbps"}
-				return DedicatedServerApi{}.UpdateBandWidthNotificationSetting("server-id", "notification id", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.UpdateBandWidthNotificationSetting(ctx, "server-id", "notification id", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7125,7 +7387,8 @@ func TestDedicatedServerUpdateBandWidthNotificationSettingServerErrors(t *testin
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"frequency": "MONTHLY", "threshold": "2", "unit": "Mbps"}
-				return DedicatedServerApi{}.UpdateBandWidthNotificationSetting("server-id", "notification id", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.UpdateBandWidthNotificationSetting(ctx, "server-id", "notification id", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7143,7 +7406,8 @@ func TestDedicatedServerUpdateBandWidthNotificationSettingServerErrors(t *testin
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"frequency": "MONTHLY", "threshold": "2", "unit": "Mbps"}
-				return DedicatedServerApi{}.UpdateBandWidthNotificationSetting("server-id", "notification id", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.UpdateBandWidthNotificationSetting(ctx, "server-id", "notification id", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7199,7 +7463,8 @@ func TestDedicatedServerListDataTrafficNotificationSettings(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := DedicatedServerApi{}.ListDataTrafficNotificationSettings("server-id")
+	ctx := context.Background()
+	resp, err := DedicatedServerApi{}.ListDataTrafficNotificationSettings(ctx, "server-id")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(resp.Metadata.TotalCount, 2)
@@ -7256,7 +7521,8 @@ func TestDedicatedServerListDataTrafficNotificationSettingsPaginate(t *testing.T
 	})
 	defer teardown()
 
-	resp, err := DedicatedServerApi{}.ListDataTrafficNotificationSettings("server-id", 1)
+	ctx := context.Background()
+	resp, err := DedicatedServerApi{}.ListDataTrafficNotificationSettings(ctx, "server-id", 1)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(resp.Metadata.TotalCount, 11)
@@ -7285,7 +7551,8 @@ func TestDedicatedServerListDataTrafficNotificationSettingsServerErrors(t *testi
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListDataTrafficNotificationSettings("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListDataTrafficNotificationSettings(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7302,7 +7569,8 @@ func TestDedicatedServerListDataTrafficNotificationSettingsServerErrors(t *testi
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListDataTrafficNotificationSettings("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListDataTrafficNotificationSettings(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7319,7 +7587,8 @@ func TestDedicatedServerListDataTrafficNotificationSettingsServerErrors(t *testi
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListDataTrafficNotificationSettings("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListDataTrafficNotificationSettings(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7336,7 +7605,8 @@ func TestDedicatedServerListDataTrafficNotificationSettingsServerErrors(t *testi
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListDataTrafficNotificationSettings("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListDataTrafficNotificationSettings(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7353,7 +7623,8 @@ func TestDedicatedServerListDataTrafficNotificationSettingsServerErrors(t *testi
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListDataTrafficNotificationSettings("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListDataTrafficNotificationSettings(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7386,7 +7657,8 @@ func TestDedicatedServerCreateDataTrafficNotificationSetting(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := DedicatedServerApi{}.CreateDataTrafficNotificationSetting("server-id", "WEEKLY", "1", "GB")
+	ctx := context.Background()
+	resp, err := DedicatedServerApi{}.CreateDataTrafficNotificationSetting(ctx, "server-id", "WEEKLY", "1", "GB")
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -7411,7 +7683,8 @@ func TestDedicatedServerCreateDataTrafficNotificationSettingServerErrors(t *test
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.CreateDataTrafficNotificationSetting("server-id", "WEEKLY", "1", "GB")
+				ctx := context.Background()
+				return DedicatedServerApi{}.CreateDataTrafficNotificationSetting(ctx, "server-id", "WEEKLY", "1", "GB")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7428,7 +7701,8 @@ func TestDedicatedServerCreateDataTrafficNotificationSettingServerErrors(t *test
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.CreateDataTrafficNotificationSetting("server-id", "WEEKLY", "1", "GB")
+				ctx := context.Background()
+				return DedicatedServerApi{}.CreateDataTrafficNotificationSetting(ctx, "server-id", "WEEKLY", "1", "GB")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7445,7 +7719,8 @@ func TestDedicatedServerCreateDataTrafficNotificationSettingServerErrors(t *test
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.CreateDataTrafficNotificationSetting("server-id", "WEEKLY", "1", "GB")
+				ctx := context.Background()
+				return DedicatedServerApi{}.CreateDataTrafficNotificationSetting(ctx, "server-id", "WEEKLY", "1", "GB")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7462,7 +7737,8 @@ func TestDedicatedServerCreateDataTrafficNotificationSettingServerErrors(t *test
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.CreateDataTrafficNotificationSetting("server-id", "WEEKLY", "1", "GB")
+				ctx := context.Background()
+				return DedicatedServerApi{}.CreateDataTrafficNotificationSetting(ctx, "server-id", "WEEKLY", "1", "GB")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7479,7 +7755,8 @@ func TestDedicatedServerCreateDataTrafficNotificationSettingServerErrors(t *test
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.CreateDataTrafficNotificationSetting("server-id", "WEEKLY", "1", "GB")
+				ctx := context.Background()
+				return DedicatedServerApi{}.CreateDataTrafficNotificationSetting(ctx, "server-id", "WEEKLY", "1", "GB")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7499,7 +7776,8 @@ func TestDedicatedServerDeleteDataTrafficNotificationSetting(t *testing.T) {
 	})
 	defer teardown()
 
-	err := DedicatedServerApi{}.DeleteDataTrafficNotificationSetting("server id", "notification id")
+	ctx := context.Background()
+	err := DedicatedServerApi{}.DeleteDataTrafficNotificationSetting(ctx, "server id", "notification id")
 	assert := assert.New(t)
 	assert.Nil(err)
 }
@@ -7515,7 +7793,8 @@ func TestDedicatedServerDeleteDataTrafficNotificationSettingServerErrors(t *test
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.DeleteDataTrafficNotificationSetting("server id", "notification id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.DeleteDataTrafficNotificationSetting(ctx, "server id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7532,7 +7811,8 @@ func TestDedicatedServerDeleteDataTrafficNotificationSettingServerErrors(t *test
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.DeleteDataTrafficNotificationSetting("server id", "notification id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.DeleteDataTrafficNotificationSetting(ctx, "server id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7549,7 +7829,8 @@ func TestDedicatedServerDeleteDataTrafficNotificationSettingServerErrors(t *test
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.DeleteDataTrafficNotificationSetting("server id", "notification id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.DeleteDataTrafficNotificationSetting(ctx, "server id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7566,7 +7847,8 @@ func TestDedicatedServerDeleteDataTrafficNotificationSettingServerErrors(t *test
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.DeleteDataTrafficNotificationSetting("server id", "notification id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.DeleteDataTrafficNotificationSetting(ctx, "server id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7583,7 +7865,8 @@ func TestDedicatedServerDeleteDataTrafficNotificationSettingServerErrors(t *test
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.DeleteDataTrafficNotificationSetting("server id", "notification id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.DeleteDataTrafficNotificationSetting(ctx, "server id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7616,7 +7899,8 @@ func TestDedicatedServerGetDataTrafficNotificationSetting(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := DedicatedServerApi{}.GetDataTrafficNotificationSetting("server-id", "notification id")
+	ctx := context.Background()
+	resp, err := DedicatedServerApi{}.GetDataTrafficNotificationSetting(ctx, "server-id", "notification id")
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -7641,7 +7925,8 @@ func TestDedicatedServerGetDataTrafficNotificationSettingServerErrors(t *testing
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetDataTrafficNotificationSetting("server-id", "notification id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetDataTrafficNotificationSetting(ctx, "server-id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7658,7 +7943,8 @@ func TestDedicatedServerGetDataTrafficNotificationSettingServerErrors(t *testing
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetDataTrafficNotificationSetting("server-id", "notification id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetDataTrafficNotificationSetting(ctx, "server-id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7675,7 +7961,8 @@ func TestDedicatedServerGetDataTrafficNotificationSettingServerErrors(t *testing
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetDataTrafficNotificationSetting("server-id", "notification id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetDataTrafficNotificationSetting(ctx, "server-id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7692,7 +7979,8 @@ func TestDedicatedServerGetDataTrafficNotificationSettingServerErrors(t *testing
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetDataTrafficNotificationSetting("server-id", "notification id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetDataTrafficNotificationSetting(ctx, "server-id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7709,7 +7997,8 @@ func TestDedicatedServerGetDataTrafficNotificationSettingServerErrors(t *testing
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetDataTrafficNotificationSetting("server-id", "notification id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetDataTrafficNotificationSetting(ctx, "server-id", "notification id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7743,7 +8032,8 @@ func TestDedicatedServerUpdateDataTrafficNotificationSetting(t *testing.T) {
 	defer teardown()
 
 	payload := map[string]string{"frequency": "MONTHLY", "threshold": "2", "unit": "GB"}
-	resp, err := DedicatedServerApi{}.UpdateDataTrafficNotificationSetting("server-id", "notification id", payload)
+	ctx := context.Background()
+	resp, err := DedicatedServerApi{}.UpdateDataTrafficNotificationSetting(ctx, "server-id", "notification id", payload)
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -7769,7 +8059,8 @@ func TestDedicatedServerUpdateDataTrafficNotificationSettingServerErrors(t *test
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"frequency": "MONTHLY", "threshold": "2", "unit": "GB"}
-				return DedicatedServerApi{}.UpdateDataTrafficNotificationSetting("server-id", "notification id", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.UpdateDataTrafficNotificationSetting(ctx, "server-id", "notification id", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7787,7 +8078,8 @@ func TestDedicatedServerUpdateDataTrafficNotificationSettingServerErrors(t *test
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"frequency": "MONTHLY", "threshold": "2", "unit": "GB"}
-				return DedicatedServerApi{}.UpdateDataTrafficNotificationSetting("server-id", "notification id", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.UpdateDataTrafficNotificationSetting(ctx, "server-id", "notification id", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7805,7 +8097,8 @@ func TestDedicatedServerUpdateDataTrafficNotificationSettingServerErrors(t *test
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"frequency": "MONTHLY", "threshold": "2", "unit": "GB"}
-				return DedicatedServerApi{}.UpdateDataTrafficNotificationSetting("server-id", "notification id", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.UpdateDataTrafficNotificationSetting(ctx, "server-id", "notification id", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7823,7 +8116,8 @@ func TestDedicatedServerUpdateDataTrafficNotificationSettingServerErrors(t *test
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"frequency": "MONTHLY", "threshold": "2", "unit": "GB"}
-				return DedicatedServerApi{}.UpdateDataTrafficNotificationSetting("server-id", "notification id", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.UpdateDataTrafficNotificationSetting(ctx, "server-id", "notification id", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7841,7 +8135,8 @@ func TestDedicatedServerUpdateDataTrafficNotificationSettingServerErrors(t *test
 			},
 			FunctionCall: func() (interface{}, error) {
 				payload := map[string]string{"frequency": "MONTHLY", "threshold": "2", "unit": "GB"}
-				return DedicatedServerApi{}.UpdateDataTrafficNotificationSetting("server-id", "notification id", payload)
+				ctx := context.Background()
+				return DedicatedServerApi{}.UpdateDataTrafficNotificationSetting(ctx, "server-id", "notification id", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7864,7 +8159,8 @@ func TestDedicatedServerGetDdosNotificationSetting(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := DedicatedServerApi{}.GetDdosNotificationSetting("server-id")
+	ctx := context.Background()
+	resp, err := DedicatedServerApi{}.GetDdosNotificationSetting(ctx, "server-id")
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -7883,7 +8179,8 @@ func TestDedicatedServerGetDdosNotificationSettingServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetDdosNotificationSetting("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetDdosNotificationSetting(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7900,7 +8197,8 @@ func TestDedicatedServerGetDdosNotificationSettingServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetDdosNotificationSetting("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetDdosNotificationSetting(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7917,7 +8215,8 @@ func TestDedicatedServerGetDdosNotificationSettingServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetDdosNotificationSetting("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetDdosNotificationSetting(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7934,7 +8233,8 @@ func TestDedicatedServerGetDdosNotificationSettingServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetDdosNotificationSetting("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetDdosNotificationSetting(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7951,7 +8251,8 @@ func TestDedicatedServerGetDdosNotificationSettingServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetDdosNotificationSetting("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetDdosNotificationSetting(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -7971,7 +8272,8 @@ func TestDedicatedServerUpdateDdosNotificationSetting(t *testing.T) {
 	})
 	defer teardown()
 
-	err := DedicatedServerApi{}.UpdateDdosNotificationSetting("server id", map[string]string{"nulling": "DISABLED", "scrubbing": "ENABLED"})
+	ctx := context.Background()
+	err := DedicatedServerApi{}.UpdateDdosNotificationSetting(ctx, "server id", map[string]string{"nulling": "DISABLED", "scrubbing": "ENABLED"})
 	assert := assert.New(t)
 	assert.Nil(err)
 }
@@ -7987,7 +8289,8 @@ func TestDedicatedServerUpdateDdosNotificationSettingServerErrors(t *testing.T) 
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.UpdateDdosNotificationSetting("server id", map[string]string{"nulling": "DISABLED", "scrubbing": "ENABLED"})
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.UpdateDdosNotificationSetting(ctx, "server id", map[string]string{"nulling": "DISABLED", "scrubbing": "ENABLED"})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8004,7 +8307,8 @@ func TestDedicatedServerUpdateDdosNotificationSettingServerErrors(t *testing.T) 
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.UpdateDdosNotificationSetting("server id", map[string]string{"nulling": "DISABLED", "scrubbing": "ENABLED"})
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.UpdateDdosNotificationSetting(ctx, "server id", map[string]string{"nulling": "DISABLED", "scrubbing": "ENABLED"})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8021,7 +8325,8 @@ func TestDedicatedServerUpdateDdosNotificationSettingServerErrors(t *testing.T) 
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.UpdateDdosNotificationSetting("server id", map[string]string{"nulling": "DISABLED", "scrubbing": "ENABLED"})
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.UpdateDdosNotificationSetting(ctx, "server id", map[string]string{"nulling": "DISABLED", "scrubbing": "ENABLED"})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8038,7 +8343,8 @@ func TestDedicatedServerUpdateDdosNotificationSettingServerErrors(t *testing.T) 
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.UpdateDdosNotificationSetting("server id", map[string]string{"nulling": "DISABLED", "scrubbing": "ENABLED"})
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.UpdateDdosNotificationSetting(ctx, "server id", map[string]string{"nulling": "DISABLED", "scrubbing": "ENABLED"})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8055,7 +8361,8 @@ func TestDedicatedServerUpdateDdosNotificationSettingServerErrors(t *testing.T) 
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.UpdateDdosNotificationSetting("server id", map[string]string{"nulling": "DISABLED", "scrubbing": "ENABLED"})
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.UpdateDdosNotificationSetting(ctx, "server id", map[string]string{"nulling": "DISABLED", "scrubbing": "ENABLED"})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8075,7 +8382,8 @@ func TestDedicatedServerPowerCycleServer(t *testing.T) {
 	})
 	defer teardown()
 
-	err := DedicatedServerApi{}.PowerCycleServer("server id")
+	ctx := context.Background()
+	err := DedicatedServerApi{}.PowerCycleServer(ctx, "server id")
 	assert := assert.New(t)
 	assert.Nil(err)
 }
@@ -8091,7 +8399,8 @@ func TestDedicatedServerPowerCycleServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.PowerCycleServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.PowerCycleServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8108,7 +8417,8 @@ func TestDedicatedServerPowerCycleServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.PowerCycleServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.PowerCycleServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8125,7 +8435,8 @@ func TestDedicatedServerPowerCycleServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.PowerCycleServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.PowerCycleServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8142,7 +8453,8 @@ func TestDedicatedServerPowerCycleServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.PowerCycleServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.PowerCycleServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8159,7 +8471,8 @@ func TestDedicatedServerPowerCycleServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.PowerCycleServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.PowerCycleServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8179,7 +8492,8 @@ func TestDedicatedServerPowerOffServer(t *testing.T) {
 	})
 	defer teardown()
 
-	err := DedicatedServerApi{}.PowerOffServer("server id")
+	ctx := context.Background()
+	err := DedicatedServerApi{}.PowerOffServer(ctx, "server id")
 	assert := assert.New(t)
 	assert.Nil(err)
 }
@@ -8195,7 +8509,8 @@ func TestDedicatedServerPowerOffServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.PowerOffServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.PowerOffServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8212,7 +8527,8 @@ func TestDedicatedServerPowerOffServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.PowerOffServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.PowerOffServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8229,7 +8545,8 @@ func TestDedicatedServerPowerOffServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.PowerOffServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.PowerOffServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8246,7 +8563,8 @@ func TestDedicatedServerPowerOffServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.PowerOffServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.PowerOffServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8263,7 +8581,8 @@ func TestDedicatedServerPowerOffServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.PowerOffServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.PowerOffServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8283,7 +8602,8 @@ func TestDedicatedServerPowerOnServer(t *testing.T) {
 	})
 	defer teardown()
 
-	err := DedicatedServerApi{}.PowerOnServer("server id")
+	ctx := context.Background()
+	err := DedicatedServerApi{}.PowerOnServer(ctx, "server id")
 	assert := assert.New(t)
 	assert.Nil(err)
 }
@@ -8299,7 +8619,8 @@ func TestDedicatedServerPowerOnServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.PowerOnServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.PowerOnServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8316,7 +8637,8 @@ func TestDedicatedServerPowerOnServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.PowerOnServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.PowerOnServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8333,7 +8655,8 @@ func TestDedicatedServerPowerOnServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.PowerOnServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.PowerOnServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8350,7 +8673,8 @@ func TestDedicatedServerPowerOnServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.PowerOnServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.PowerOnServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8367,7 +8691,8 @@ func TestDedicatedServerPowerOnServerServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, DedicatedServerApi{}.PowerOnServer("server id")
+				ctx := context.Background()
+				return nil, DedicatedServerApi{}.PowerOnServer(ctx, "server id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8394,7 +8719,8 @@ func TestDedicatedServerGetPowerStatus(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := DedicatedServerApi{}.GetPowerStatus("server-id")
+	ctx := context.Background()
+	resp, err := DedicatedServerApi{}.GetPowerStatus(ctx, "server-id")
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -8413,7 +8739,8 @@ func TestDedicatedServerGetPowerStatusServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetPowerStatus("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetPowerStatus(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8430,7 +8757,8 @@ func TestDedicatedServerGetPowerStatusServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetPowerStatus("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetPowerStatus(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8447,7 +8775,8 @@ func TestDedicatedServerGetPowerStatusServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetPowerStatus("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetPowerStatus(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8464,7 +8793,8 @@ func TestDedicatedServerGetPowerStatusServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetPowerStatus("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetPowerStatus(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8481,7 +8811,8 @@ func TestDedicatedServerGetPowerStatusServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetPowerStatus("server-id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetPowerStatus(ctx, "server-id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8517,7 +8848,8 @@ func TestDedicatedServerListOperatingSystems(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedServerApi{}.ListOperatingSystems()
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.ListOperatingSystems(ctx)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 2)
@@ -8551,7 +8883,8 @@ func TestDedicatedServerListOperatingSystemsPagination(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedServerApi{}.ListOperatingSystems()
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.ListOperatingSystems(ctx)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 11)
@@ -8574,7 +8907,8 @@ func TestDedicatedServerListOperatingSystemsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListOperatingSystems()
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListOperatingSystems(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8591,7 +8925,8 @@ func TestDedicatedServerListOperatingSystemsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListOperatingSystems()
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListOperatingSystems(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8608,7 +8943,8 @@ func TestDedicatedServerListOperatingSystemsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListOperatingSystems()
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListOperatingSystems(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8625,7 +8961,8 @@ func TestDedicatedServerListOperatingSystemsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListOperatingSystems()
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListOperatingSystems(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8699,7 +9036,8 @@ func TestDedicatedServerGetOperatingSystem(t *testing.T) {
 	})
 	defer teardown()
 
-	OperatingSystem, err := DedicatedServerApi{}.GetOperatingSystem("UBUNTU_20_04_64BIT", "controll panel id")
+	ctx := context.Background()
+	OperatingSystem, err := DedicatedServerApi{}.GetOperatingSystem(ctx, "UBUNTU_20_04_64BIT", "controll panel id")
 	assert := assert.New(t)
 	assert.Nil(err)
 
@@ -8752,7 +9090,8 @@ func TestDedicatedServerGetOperatingSystemServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetOperatingSystem("UBUNTU_20_04_64BIT", "controll panel id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetOperatingSystem(ctx, "UBUNTU_20_04_64BIT", "controll panel id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8769,7 +9108,8 @@ func TestDedicatedServerGetOperatingSystemServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetOperatingSystem("UBUNTU_20_04_64BIT", "controll panel id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetOperatingSystem(ctx, "UBUNTU_20_04_64BIT", "controll panel id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8786,7 +9126,8 @@ func TestDedicatedServerGetOperatingSystemServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetOperatingSystem("UBUNTU_20_04_64BIT", "controll panel id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetOperatingSystem(ctx, "UBUNTU_20_04_64BIT", "controll panel id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8803,7 +9144,8 @@ func TestDedicatedServerGetOperatingSystemServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.GetOperatingSystem("UBUNTU_20_04_64BIT", "controll panel id")
+				ctx := context.Background()
+				return DedicatedServerApi{}.GetOperatingSystem(ctx, "UBUNTU_20_04_64BIT", "controll panel id")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8839,7 +9181,8 @@ func TestDedicatedServerListControlPanels(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedServerApi{}.ListControlPanels()
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.ListControlPanels(ctx)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 2)
@@ -8873,7 +9216,8 @@ func TestDedicatedServerListControlPanelsPagination(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedServerApi{}.ListControlPanels(1)
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.ListControlPanels(ctx, 1)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 11)
@@ -8896,7 +9240,8 @@ func TestDedicatedServerListControlPanelsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListControlPanels()
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListControlPanels(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8913,7 +9258,8 @@ func TestDedicatedServerListControlPanelsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListControlPanels()
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListControlPanels(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8930,7 +9276,8 @@ func TestDedicatedServerListControlPanelsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListControlPanels()
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListControlPanels(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8947,7 +9294,8 @@ func TestDedicatedServerListControlPanelsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListControlPanels()
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListControlPanels(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -8983,7 +9331,8 @@ func TestDedicatedServerListRescueImages(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedServerApi{}.ListRescueImages()
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.ListRescueImages(ctx)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 2)
@@ -9017,7 +9366,8 @@ func TestDedicatedServerListRescueImagesPagination(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := DedicatedServerApi{}.ListRescueImages(1)
+	ctx := context.Background()
+	response, err := DedicatedServerApi{}.ListRescueImages(ctx, 1)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 11)
@@ -9040,7 +9390,8 @@ func TestDedicatedServerListRescueImagesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListRescueImages()
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListRescueImages(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -9057,7 +9408,8 @@ func TestDedicatedServerListRescueImagesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListRescueImages()
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListRescueImages(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -9074,7 +9426,8 @@ func TestDedicatedServerListRescueImagesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListRescueImages()
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListRescueImages(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -9091,7 +9444,8 @@ func TestDedicatedServerListRescueImagesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return DedicatedServerApi{}.ListRescueImages()
+				ctx := context.Background()
+				return DedicatedServerApi{}.ListRescueImages(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",

--- a/floating_ip.go
+++ b/floating_ip.go
@@ -1,6 +1,7 @@
 package leaseweb
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -49,7 +50,7 @@ func (fia FloatingIpApi) getPath(endpoint string) string {
 	return "/floatingIps/" + FLOATING_IP_API_VERSION + endpoint
 }
 
-func (fia FloatingIpApi) ListRanges(args ...interface{}) (*FloatingIpRanges, error) {
+func (fia FloatingIpApi) ListRanges(ctx context.Context, args ...interface{}) (*FloatingIpRanges, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -71,22 +72,22 @@ func (fia FloatingIpApi) ListRanges(args ...interface{}) (*FloatingIpRanges, err
 
 	path := fia.getPath("/ranges?" + v.Encode())
 	result := &FloatingIpRanges{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (fia FloatingIpApi) GetRange(rangeId string) (*FloatingIpRange, error) {
+func (fia FloatingIpApi) GetRange(ctx context.Context, rangeId string) (*FloatingIpRange, error) {
 	path := fia.getPath("/ranges/" + rangeId)
 	result := &FloatingIpRange{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (fia FloatingIpApi) ListRangeDefinitions(rangeId string, args ...interface{}) (*FloatingIpDefinitions, error) {
+func (fia FloatingIpApi) ListRangeDefinitions(ctx context.Context, rangeId string, args ...interface{}) (*FloatingIpDefinitions, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -108,45 +109,45 @@ func (fia FloatingIpApi) ListRangeDefinitions(rangeId string, args ...interface{
 
 	path := fia.getPath("/ranges/" + rangeId + "/floatingIpDefinitions?" + v.Encode())
 	result := &FloatingIpDefinitions{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (fia FloatingIpApi) CreateRangeDefinition(rangeId string, floatingIp string, anchorIp string) (*FloatingIpDefinition, error) {
+func (fia FloatingIpApi) CreateRangeDefinition(ctx context.Context, rangeId string, floatingIp string, anchorIp string) (*FloatingIpDefinition, error) {
 	payload := map[string]string{"floatingIp": floatingIp, "anchorIp": anchorIp}
 	path := fia.getPath("/ranges/" + rangeId + "/floatingIpDefinitions")
 	result := &FloatingIpDefinition{}
-	if err := doRequest(http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (fia FloatingIpApi) GetRangeDefinition(rangeId string, floatingIpDefinitionId string) (*FloatingIpDefinition, error) {
+func (fia FloatingIpApi) GetRangeDefinition(ctx context.Context, rangeId string, floatingIpDefinitionId string) (*FloatingIpDefinition, error) {
 	path := fia.getPath("/ranges/" + rangeId + "/floatingIpDefinitions/" + floatingIpDefinitionId)
 	result := &FloatingIpDefinition{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (fia FloatingIpApi) UpdateRangeDefinition(rangeId string, floatingIpDefinitionId string, anchorIp string) (*FloatingIpDefinition, error) {
+func (fia FloatingIpApi) UpdateRangeDefinition(ctx context.Context, rangeId string, floatingIpDefinitionId string, anchorIp string) (*FloatingIpDefinition, error) {
 	payload := map[string]string{"anchorIp": anchorIp}
 	path := fia.getPath("/ranges/" + rangeId + "/floatingIpDefinitions/" + floatingIpDefinitionId)
 	result := &FloatingIpDefinition{}
-	if err := doRequest(http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (fia FloatingIpApi) RemoveRangeDefinition(rangeId string, floatingIpDefinitionId string) (*FloatingIpDefinition, error) {
+func (fia FloatingIpApi) RemoveRangeDefinition(ctx context.Context, rangeId string, floatingIpDefinitionId string) (*FloatingIpDefinition, error) {
 	path := fia.getPath("/ranges/" + rangeId + "/floatingIpDefinitions/" + floatingIpDefinitionId)
 	result := &FloatingIpDefinition{}
-	if err := doRequest(http.MethodDelete, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodDelete, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/floating_ip_test.go
+++ b/floating_ip_test.go
@@ -1,6 +1,7 @@
 package leaseweb
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -34,7 +35,8 @@ func TestFloatingIpListRanges(t *testing.T) {
 	defer teardown()
 
 	floatingIpApi := FloatingIpApi{}
-	response, err := floatingIpApi.ListRanges()
+	ctx := context.Background()
+	response, err := floatingIpApi.ListRanges(ctx)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -78,7 +80,8 @@ func TestFloatingIpListRangesPaginateAndFilter(t *testing.T) {
 	defer teardown()
 
 	floatingIpApi := FloatingIpApi{}
-	response, err := floatingIpApi.ListRanges(1, 10, []string{"SITE", "METRO"}, "AMS-01")
+	ctx := context.Background()
+	response, err := floatingIpApi.ListRanges(ctx, 1, 10, []string{"SITE", "METRO"}, "AMS-01")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -107,7 +110,8 @@ func TestFloatingIpListRangesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return FloatingIpApi{}.ListRanges()
+				ctx := context.Background()
+				return FloatingIpApi{}.ListRanges(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -124,7 +128,8 @@ func TestFloatingIpListRangesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return FloatingIpApi{}.ListRanges()
+				ctx := context.Background()
+				return FloatingIpApi{}.ListRanges(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -141,7 +146,8 @@ func TestFloatingIpListRangesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return FloatingIpApi{}.ListRanges()
+				ctx := context.Background()
+				return FloatingIpApi{}.ListRanges(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -169,7 +175,8 @@ func TestFloatingIpGetRange(t *testing.T) {
 	defer teardown()
 
 	floatingIpApi := FloatingIpApi{}
-	response, err := floatingIpApi.GetRange("123456789")
+	ctx := context.Background()
+	response, err := floatingIpApi.GetRange(ctx, "123456789")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -193,7 +200,8 @@ func TestFloatingIpGetRangeServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return FloatingIpApi{}.GetRange("123456789")
+				ctx := context.Background()
+				return FloatingIpApi{}.GetRange(ctx, "123456789")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "ACCESS_DENIED",
@@ -209,7 +217,8 @@ func TestFloatingIpGetRangeServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "39e010ed-0e93-42c3-c28f-3ffc373553d5", "errorCode": "404", "errorMessage": "Range with id 88.17.0.0_17 does not exist"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return FloatingIpApi{}.GetRange("123456789")
+				ctx := context.Background()
+				return FloatingIpApi{}.GetRange(ctx, "123456789")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "39e010ed-0e93-42c3-c28f-3ffc373553d5",
@@ -226,7 +235,8 @@ func TestFloatingIpGetRangeServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return FloatingIpApi{}.GetRange("123456789")
+				ctx := context.Background()
+				return FloatingIpApi{}.GetRange(ctx, "123456789")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -243,7 +253,8 @@ func TestFloatingIpGetRangeServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return FloatingIpApi{}.GetRange("123456789")
+				ctx := context.Background()
+				return FloatingIpApi{}.GetRange(ctx, "123456789")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -291,7 +302,8 @@ func TestFloatingIpListRangeDefinitions(t *testing.T) {
 	defer teardown()
 
 	floatingIpApi := FloatingIpApi{}
-	response, err := floatingIpApi.ListRangeDefinitions("123456789")
+	ctx := context.Background()
+	response, err := floatingIpApi.ListRangeDefinitions(ctx, "123456789")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -350,7 +362,8 @@ func TestFloatingIpListRangeDefinitionsPaginateAndFilter(t *testing.T) {
 	defer teardown()
 
 	floatingIpApi := FloatingIpApi{}
-	response, err := floatingIpApi.ListRangeDefinitions("123456789", 1, 10, []string{"SITE", "METRO"}, "AMS-01")
+	ctx := context.Background()
+	response, err := floatingIpApi.ListRangeDefinitions(ctx, "123456789", 1, 10, []string{"SITE", "METRO"}, "AMS-01")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -383,7 +396,8 @@ func TestFloatingIpListRangeDefinitionsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return FloatingIpApi{}.ListRangeDefinitions("123456789")
+				ctx := context.Background()
+				return FloatingIpApi{}.ListRangeDefinitions(ctx, "123456789")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "ACCESS_DENIED",
@@ -399,7 +413,8 @@ func TestFloatingIpListRangeDefinitionsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "39e010ed-0e93-42c3-c28f-3ffc373553d5", "errorCode": "404", "errorMessage": "Range with id 88.17.0.0_17 does not exist"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return FloatingIpApi{}.ListRangeDefinitions("123456789")
+				ctx := context.Background()
+				return FloatingIpApi{}.ListRangeDefinitions(ctx, "123456789")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "39e010ed-0e93-42c3-c28f-3ffc373553d5",
@@ -416,7 +431,8 @@ func TestFloatingIpListRangeDefinitionsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return FloatingIpApi{}.ListRangeDefinitions("123456789")
+				ctx := context.Background()
+				return FloatingIpApi{}.ListRangeDefinitions(ctx, "123456789")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -433,7 +449,8 @@ func TestFloatingIpListRangeDefinitionsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return FloatingIpApi{}.ListRangeDefinitions("123456789")
+				ctx := context.Background()
+				return FloatingIpApi{}.ListRangeDefinitions(ctx, "123456789")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -466,7 +483,8 @@ func TestFloatingIpCreateRangeDefinition(t *testing.T) {
 	defer teardown()
 
 	floatingIpApi := FloatingIpApi{}
-	response, err := floatingIpApi.CreateRangeDefinition("10.0.0.0_29", "88.17.0.5/32", "95.10.126.1")
+	ctx := context.Background()
+	response, err := floatingIpApi.CreateRangeDefinition(ctx, "10.0.0.0_29", "88.17.0.5/32", "95.10.126.1")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -495,7 +513,8 @@ func TestFloatingIpCreateRangeDefinitionServerError(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "400", "errorMessage": "Validation Failed"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return FloatingIpApi{}.CreateRangeDefinition("10.0.0.0_29", "88.17.0.5/32", "95.10.126.1")
+				ctx := context.Background()
+				return FloatingIpApi{}.CreateRangeDefinition(ctx, "10.0.0.0_29", "88.17.0.5/32", "95.10.126.1")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "400",
@@ -511,7 +530,8 @@ func TestFloatingIpCreateRangeDefinitionServerError(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return FloatingIpApi{}.CreateRangeDefinition("10.0.0.0_29", "88.17.0.5/32", "95.10.126.1")
+				ctx := context.Background()
+				return FloatingIpApi{}.CreateRangeDefinition(ctx, "10.0.0.0_29", "88.17.0.5/32", "95.10.126.1")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "ACCESS_DENIED",
@@ -527,7 +547,8 @@ func TestFloatingIpCreateRangeDefinitionServerError(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return FloatingIpApi{}.CreateRangeDefinition("10.0.0.0_29", "88.17.0.5/32", "95.10.126.1")
+				ctx := context.Background()
+				return FloatingIpApi{}.CreateRangeDefinition(ctx, "10.0.0.0_29", "88.17.0.5/32", "95.10.126.1")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -544,7 +565,8 @@ func TestFloatingIpCreateRangeDefinitionServerError(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return FloatingIpApi{}.CreateRangeDefinition("10.0.0.0_29", "88.17.0.5/32", "95.10.126.1")
+				ctx := context.Background()
+				return FloatingIpApi{}.CreateRangeDefinition(ctx, "10.0.0.0_29", "88.17.0.5/32", "95.10.126.1")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -577,7 +599,8 @@ func TestFloatingIpGetRangeDefinition(t *testing.T) {
 	defer teardown()
 
 	floatingIpApi := FloatingIpApi{}
-	response, err := floatingIpApi.GetRangeDefinition("88.17.0.0_17", "88.17.34.108_32")
+	ctx := context.Background()
+	response, err := floatingIpApi.GetRangeDefinition(ctx, "88.17.0.0_17", "88.17.34.108_32")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -606,7 +629,8 @@ func TestFloatingIpGetRangeDefinitionServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return FloatingIpApi{}.GetRangeDefinition("88.17.0.0_17", "88.17.34.108_32")
+				ctx := context.Background()
+				return FloatingIpApi{}.GetRangeDefinition(ctx, "88.17.0.0_17", "88.17.34.108_32")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "ACCESS_DENIED",
@@ -622,7 +646,8 @@ func TestFloatingIpGetRangeDefinitionServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return FloatingIpApi{}.GetRangeDefinition("88.17.0.0_17", "88.17.34.108_32")
+				ctx := context.Background()
+				return FloatingIpApi{}.GetRangeDefinition(ctx, "88.17.0.0_17", "88.17.34.108_32")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -639,7 +664,8 @@ func TestFloatingIpGetRangeDefinitionServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return FloatingIpApi{}.GetRangeDefinition("88.17.0.0_17", "88.17.34.108_32")
+				ctx := context.Background()
+				return FloatingIpApi{}.GetRangeDefinition(ctx, "88.17.0.0_17", "88.17.34.108_32")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -672,7 +698,8 @@ func TestFloatingIpUpdateRangeDefinition(t *testing.T) {
 	defer teardown()
 
 	floatingIpApi := FloatingIpApi{}
-	response, err := floatingIpApi.UpdateRangeDefinition("88.17.0.0_17", "88.17.34.108_32", "95.10.126.1")
+	ctx := context.Background()
+	response, err := floatingIpApi.UpdateRangeDefinition(ctx, "88.17.0.0_17", "88.17.34.108_32", "95.10.126.1")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -701,7 +728,8 @@ func TestFloatingIpUpdateRangeDefinitionServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "945bef2e-1caf-4027-bd0a-8976848f3dee", "errorCode": "400", "errorMessage": "Validation Failed"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return FloatingIpApi{}.UpdateRangeDefinition("wrong 1", "88.17.34.108_32", "95.10.126.1")
+				ctx := context.Background()
+				return FloatingIpApi{}.UpdateRangeDefinition(ctx, "wrong 1", "88.17.34.108_32", "95.10.126.1")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "945bef2e-1caf-4027-bd0a-8976848f3dee",
@@ -718,7 +746,8 @@ func TestFloatingIpUpdateRangeDefinitionServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return FloatingIpApi{}.UpdateRangeDefinition("wrong 1", "88.17.34.108_32", "95.10.126.1")
+				ctx := context.Background()
+				return FloatingIpApi{}.UpdateRangeDefinition(ctx, "wrong 1", "88.17.34.108_32", "95.10.126.1")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "ACCESS_DENIED",
@@ -734,7 +763,8 @@ func TestFloatingIpUpdateRangeDefinitionServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return FloatingIpApi{}.UpdateRangeDefinition("wrong 1", "88.17.34.108_32", "95.10.126.1")
+				ctx := context.Background()
+				return FloatingIpApi{}.UpdateRangeDefinition(ctx, "wrong 1", "88.17.34.108_32", "95.10.126.1")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -751,7 +781,8 @@ func TestFloatingIpUpdateRangeDefinitionServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return FloatingIpApi{}.UpdateRangeDefinition("wrong 1", "88.17.34.108_32", "95.10.126.1")
+				ctx := context.Background()
+				return FloatingIpApi{}.UpdateRangeDefinition(ctx, "wrong 1", "88.17.34.108_32", "95.10.126.1")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -784,7 +815,8 @@ func TestFloatingIpRemoveRangeDefinition(t *testing.T) {
 	defer teardown()
 
 	floatingIpApi := FloatingIpApi{}
-	response, err := floatingIpApi.RemoveRangeDefinition("88.17.0.0_17", "88.17.34.108_32")
+	ctx := context.Background()
+	response, err := floatingIpApi.RemoveRangeDefinition(ctx, "88.17.0.0_17", "88.17.34.108_32")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -814,7 +846,8 @@ func TestFloatingIpRemoveRangeDefinitionServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return FloatingIpApi{}.RemoveRangeDefinition("88.17.0.0_17", "88.17.34.108_32")
+				ctx := context.Background()
+				return FloatingIpApi{}.RemoveRangeDefinition(ctx, "88.17.0.0_17", "88.17.34.108_32")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "ACCESS_DENIED",
@@ -830,7 +863,8 @@ func TestFloatingIpRemoveRangeDefinitionServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return FloatingIpApi{}.RemoveRangeDefinition("88.17.0.0_17", "88.17.34.108_32")
+				ctx := context.Background()
+				return FloatingIpApi{}.RemoveRangeDefinition(ctx, "88.17.0.0_17", "88.17.34.108_32")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -847,7 +881,8 @@ func TestFloatingIpRemoveRangeDefinitionServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return FloatingIpApi{}.RemoveRangeDefinition("88.17.0.0_17", "88.17.34.108_32")
+				ctx := context.Background()
+				return FloatingIpApi{}.RemoveRangeDefinition(ctx, "88.17.0.0_17", "88.17.34.108_32")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",

--- a/hosting.go
+++ b/hosting.go
@@ -1,6 +1,7 @@
 package leaseweb
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -146,7 +147,7 @@ func (ha HostingApi) getPath(endpoint string) string {
 	return "/hosting/" + FLOATING_IP_API_VERSION + endpoint
 }
 
-func (ha HostingApi) ListDomains(args ...interface{}) (*HostingDomains, error) {
+func (ha HostingApi) ListDomains(ctx context.Context, args ...interface{}) (*HostingDomains, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -160,31 +161,31 @@ func (ha HostingApi) ListDomains(args ...interface{}) (*HostingDomains, error) {
 
 	path := ha.getPath("/domains?" + v.Encode())
 	result := &HostingDomains{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ha HostingApi) GetDomain(domainName string) (*HostingDomain, error) {
+func (ha HostingApi) GetDomain(ctx context.Context, domainName string) (*HostingDomain, error) {
 	path := ha.getPath("/domains/" + domainName)
 	result := &HostingDomain{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ha HostingApi) GetAvailability(domainName string) (*HostingDomainAvailability, error) {
+func (ha HostingApi) GetAvailability(ctx context.Context, domainName string) (*HostingDomainAvailability, error) {
 	path := ha.getPath("/domains/" + domainName + "/available")
 	result := &HostingDomainAvailability{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ha HostingApi) ListNameservers(domainName string, args ...interface{}) (*HostingNameservers, error) {
+func (ha HostingApi) ListNameservers(ctx context.Context, domainName string, args ...interface{}) (*HostingNameservers, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -195,42 +196,42 @@ func (ha HostingApi) ListNameservers(domainName string, args ...interface{}) (*H
 
 	path := ha.getPath("/domains/" + domainName + "/nameservers?" + v.Encode())
 	result := &HostingNameservers{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ha HostingApi) UpdateNameservers(domainName string, nameservers []string) (*HostingNameservers, error) {
+func (ha HostingApi) UpdateNameservers(ctx context.Context, domainName string, nameservers []string) (*HostingNameservers, error) {
 	payload := make(map[string][]string)
 	payload["nameservers"] = nameservers
 	path := ha.getPath("/domains/" + domainName + "/nameservers")
 	result := &HostingNameservers{}
-	if err := doRequest(http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ha HostingApi) GetDnsSecurity(domainName string) (*HostingDnsSecurity, error) {
+func (ha HostingApi) GetDnsSecurity(ctx context.Context, domainName string) (*HostingDnsSecurity, error) {
 	path := ha.getPath("/domains/" + domainName + "/dnssec")
 	result := &HostingDnsSecurity{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ha HostingApi) UpdateDnsSecurity(domainName string, payload map[string]interface{}) (*HostingInfoMessageResponse, error) {
+func (ha HostingApi) UpdateDnsSecurity(ctx context.Context, domainName string, payload map[string]interface{}) (*HostingInfoMessageResponse, error) {
 	path := ha.getPath("/domains/" + domainName + "/dnssec")
 	result := &HostingInfoMessageResponse{}
-	if err := doRequest(http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ha HostingApi) ListResourceRecordSets(domainName string, args ...interface{}) (*HostingResourceRecordSets, error) {
+func (ha HostingApi) ListResourceRecordSets(ctx context.Context, domainName string, args ...interface{}) (*HostingResourceRecordSets, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -241,53 +242,53 @@ func (ha HostingApi) ListResourceRecordSets(domainName string, args ...interface
 
 	path := ha.getPath("/domains/" + domainName + "/resourceRecordSets?" + v.Encode())
 	result := &HostingResourceRecordSets{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ha HostingApi) CreateResourceRecordSet(domainName string, payload map[string]interface{}) (*HostingResourceRecordSet, error) {
+func (ha HostingApi) CreateResourceRecordSet(ctx context.Context, domainName string, payload map[string]interface{}) (*HostingResourceRecordSet, error) {
 	path := ha.getPath("/domains/" + domainName + "/resourceRecordSets")
 	result := &HostingResourceRecordSet{}
-	if err := doRequest(http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ha HostingApi) DeleteResourceRecordSets(domainName string) error {
+func (ha HostingApi) DeleteResourceRecordSets(ctx context.Context, domainName string) error {
 	path := ha.getPath("/domains/" + domainName + "/resourceRecordSets")
-	return doRequest(http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path)
 }
 
-func (ha HostingApi) GetResourceRecordSet(domainName, name, recordType string) (*HostingResourceRecordSet, error) {
+func (ha HostingApi) GetResourceRecordSet(ctx context.Context, domainName, name, recordType string) (*HostingResourceRecordSet, error) {
 	path := ha.getPath("/domains/" + domainName + "/resourceRecordSets/" + name + "/" + recordType)
 	result := &HostingResourceRecordSet{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ha HostingApi) UpdateResourceRecordSet(domainName, name, recordType string, content []string, ttl int) (*HostingResourceRecordSet, error) {
+func (ha HostingApi) UpdateResourceRecordSet(ctx context.Context, domainName, name, recordType string, content []string, ttl int) (*HostingResourceRecordSet, error) {
 	path := ha.getPath("/domains/" + domainName + "/resourceRecordSets/" + name + "/" + recordType)
 	result := &HostingResourceRecordSet{}
 	payload := make(map[string]interface{})
 	payload["content"] = content
 	payload["ttl"] = ttl
-	if err := doRequest(http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ha HostingApi) DeleteResourceRecordSet(domainName, name, recordType string) error {
+func (ha HostingApi) DeleteResourceRecordSet(ctx context.Context, domainName, name, recordType string) error {
 	path := ha.getPath("/domains/" + domainName + "/resourceRecordSets/" + name + "/" + recordType)
-	return doRequest(http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path)
 }
 
-func (ha HostingApi) ValidateResourceRecordSet(domainName, name, recordType string, content []string, ttl int) (*HostingInfoMessageResponse, error) {
+func (ha HostingApi) ValidateResourceRecordSet(ctx context.Context, domainName, name, recordType string, content []string, ttl int) (*HostingInfoMessageResponse, error) {
 	path := ha.getPath("/domains/" + domainName + "/resourceRecordSets/validateSet")
 	result := &HostingInfoMessageResponse{}
 	payload := make(map[string]interface{})
@@ -295,40 +296,40 @@ func (ha HostingApi) ValidateResourceRecordSet(domainName, name, recordType stri
 	payload["type"] = recordType
 	payload["content"] = content
 	payload["ttl"] = ttl
-	if err := doRequest(http.MethodPost, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ha HostingApi) ListCatchAll(domainName string) (*HostingEmail, error) {
+func (ha HostingApi) ListCatchAll(ctx context.Context, domainName string) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/catchAll")
 	result := &HostingEmail{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ha HostingApi) UpdateCatchAll(domainName string, payload map[string]interface{}) (*HostingEmail, error) {
+func (ha HostingApi) UpdateCatchAll(ctx context.Context, domainName string, payload map[string]interface{}) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/catchAll")
 	result := &HostingEmail{}
-	if err := doRequest(http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ha HostingApi) CreateCatchAll(domainName string, payload map[string]interface{}) (*HostingEmail, error) {
-	return ha.UpdateCatchAll(domainName, payload)
+func (ha HostingApi) CreateCatchAll(ctx context.Context, domainName string, payload map[string]interface{}) (*HostingEmail, error) {
+	return ha.UpdateCatchAll(ctx, domainName, payload)
 }
 
-func (ha HostingApi) DeleteCatchAll(domainName string) error {
+func (ha HostingApi) DeleteCatchAll(ctx context.Context, domainName string) error {
 	path := ha.getPath("/domains/" + domainName + "/catchAll")
-	return doRequest(http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path)
 }
 
-func (ha HostingApi) ListEmailAliases(domainName string, args ...interface{}) (*HostingEmailAliases, error) {
+func (ha HostingApi) ListEmailAliases(ctx context.Context, domainName string, args ...interface{}) (*HostingEmailAliases, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -339,45 +340,45 @@ func (ha HostingApi) ListEmailAliases(domainName string, args ...interface{}) (*
 
 	path := ha.getPath("/domains/" + domainName + "/emailAliases?" + v.Encode())
 	result := &HostingEmailAliases{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ha HostingApi) CreateEmailAlias(domainName string, payload map[string]interface{}) (*HostingEmail, error) {
+func (ha HostingApi) CreateEmailAlias(ctx context.Context, domainName string, payload map[string]interface{}) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/emailAliases")
 	result := &HostingEmail{}
-	if err := doRequest(http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ha HostingApi) GetEmailAlias(domainName, source, destination string) (*HostingEmail, error) {
+func (ha HostingApi) GetEmailAlias(ctx context.Context, domainName, source, destination string) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/emailAliases/" + source + "/" + destination)
 	result := &HostingEmail{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ha HostingApi) UpdateEmailAlias(domainName, source, destination string, payload map[string]bool) (*HostingEmail, error) {
+func (ha HostingApi) UpdateEmailAlias(ctx context.Context, domainName, source, destination string, payload map[string]bool) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/emailAliases/" + source + "/" + destination)
 	result := &HostingEmail{}
-	if err := doRequest(http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ha HostingApi) DeleteEmailAlias(domainName, source, destination string) error {
+func (ha HostingApi) DeleteEmailAlias(ctx context.Context, domainName, source, destination string) error {
 	path := ha.getPath("/domains/" + domainName + "/emailAliases/" + source + "/" + destination)
-	return doRequest(http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path)
 }
 
-func (ha HostingApi) ListDomainForwards(domainName string, args ...interface{}) (*HostingEmailForwards, error) {
+func (ha HostingApi) ListDomainForwards(ctx context.Context, domainName string, args ...interface{}) (*HostingEmailForwards, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -388,13 +389,13 @@ func (ha HostingApi) ListDomainForwards(domainName string, args ...interface{}) 
 
 	path := ha.getPath("/domains/" + domainName + "/forwards?" + v.Encode())
 	result := &HostingEmailForwards{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ha HostingApi) ListMailBoxes(domainName string, args ...interface{}) (*HostingEmailMailboxes, error) {
+func (ha HostingApi) ListMailBoxes(ctx context.Context, domainName string, args ...interface{}) (*HostingEmailMailboxes, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -405,72 +406,72 @@ func (ha HostingApi) ListMailBoxes(domainName string, args ...interface{}) (*Hos
 
 	path := ha.getPath("/domains/" + domainName + "/mailboxes?" + v.Encode())
 	result := &HostingEmailMailboxes{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ha HostingApi) CreateMailBox(domainName string, payload map[string]interface{}) (*HostingEmail, error) {
+func (ha HostingApi) CreateMailBox(ctx context.Context, domainName string, payload map[string]interface{}) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes")
 	result := &HostingEmail{}
-	if err := doRequest(http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ha HostingApi) GetMailBox(domainName, emailAddress string) (*HostingEmail, error) {
+func (ha HostingApi) GetMailBox(ctx context.Context, domainName, emailAddress string) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress)
 	result := &HostingEmail{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ha HostingApi) UpdateMailBox(domainName, emailAddress string, payload map[string]interface{}) (*HostingEmail, error) {
+func (ha HostingApi) UpdateMailBox(ctx context.Context, domainName, emailAddress string, payload map[string]interface{}) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress)
 	result := &HostingEmail{}
-	if err := doRequest(http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ha HostingApi) DeleteMailBox(domainName, emailAddress string) error {
+func (ha HostingApi) DeleteMailBox(ctx context.Context, domainName, emailAddress string) error {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress)
-	return doRequest(http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path)
 }
 
-func (ha HostingApi) GetAutoResponder(domainName, emailAddress string) (*HostingEmail, error) {
+func (ha HostingApi) GetAutoResponder(ctx context.Context, domainName, emailAddress string) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress + "/autoResponder")
 	result := &HostingEmail{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ha HostingApi) UpdateAutoResponder(domainName, emailAddress string, payload map[string]interface{}) (*HostingEmail, error) {
+func (ha HostingApi) UpdateAutoResponder(ctx context.Context, domainName, emailAddress string, payload map[string]interface{}) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress + "/autoResponder")
 	result := &HostingEmail{}
-	if err := doRequest(http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ha HostingApi) CreateAutoResponder(domainName, emailAddress string, payload map[string]interface{}) (*HostingEmail, error) {
-	return ha.UpdateAutoResponder(domainName, emailAddress, payload)
+func (ha HostingApi) CreateAutoResponder(ctx context.Context, domainName, emailAddress string, payload map[string]interface{}) (*HostingEmail, error) {
+	return ha.UpdateAutoResponder(ctx, domainName, emailAddress, payload)
 }
 
-func (ha HostingApi) DeleteAutoResponder(domainName, emailAddress string) error {
+func (ha HostingApi) DeleteAutoResponder(ctx context.Context, domainName, emailAddress string) error {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress + "/autoResponder")
-	return doRequest(http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path)
 }
 
-func (ha HostingApi) ListForwards(domainName, emailAddress string, args ...interface{}) (*HostingEmailForwards, error) {
+func (ha HostingApi) ListForwards(ctx context.Context, domainName, emailAddress string, args ...interface{}) (*HostingEmailForwards, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -481,40 +482,40 @@ func (ha HostingApi) ListForwards(domainName, emailAddress string, args ...inter
 
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress + "/forwards?" + v.Encode())
 	result := &HostingEmailForwards{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ha HostingApi) CreateForward(domainName, emailAddress string, payload map[string]interface{}) (*HostingEmail, error) {
+func (ha HostingApi) CreateForward(ctx context.Context, domainName, emailAddress string, payload map[string]interface{}) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress + "/forwards")
 	result := &HostingEmail{}
-	if err := doRequest(http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ha HostingApi) GetForward(domainName, emailAddress, destination string) (*HostingEmail, error) {
+func (ha HostingApi) GetForward(ctx context.Context, domainName, emailAddress, destination string) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress + "/forwards/" + destination)
 	result := &HostingEmail{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ha HostingApi) UpdateForward(domainName, emailAddress, destination string, payload map[string]bool) (*HostingEmail, error) {
+func (ha HostingApi) UpdateForward(ctx context.Context, domainName, emailAddress, destination string, payload map[string]bool) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress + "/forwards/" + destination)
 	result := &HostingEmail{}
-	if err := doRequest(http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ha HostingApi) DeleteForward(domainName, emailAddress, destination string) error {
+func (ha HostingApi) DeleteForward(ctx context.Context, domainName, emailAddress, destination string) error {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress + "/forwards/" + destination)
-	return doRequest(http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path)
 }

--- a/hosting_test.go
+++ b/hosting_test.go
@@ -1,6 +1,7 @@
 package leaseweb
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -104,7 +105,8 @@ func TestHostingListDomains(t *testing.T) {
 	defer teardown()
 
 	hostingApi := HostingApi{}
-	response, err := hostingApi.ListDomains()
+	ctx := context.Background()
+	response, err := hostingApi.ListDomains(ctx)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -206,7 +208,8 @@ func TestHostingListDomainsPaginateAndFilter(t *testing.T) {
 	defer teardown()
 
 	hostingApi := HostingApi{}
-	response, err := hostingApi.ListDomains(1)
+	ctx := context.Background()
+	response, err := hostingApi.ListDomains(ctx, 1)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -245,7 +248,8 @@ func TestHostingListDomainsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.ListDomains()
+				ctx := context.Background()
+				return HostingApi{}.ListDomains(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -262,7 +266,8 @@ func TestHostingListDomainsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.ListDomains()
+				ctx := context.Background()
+				return HostingApi{}.ListDomains(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -279,7 +284,8 @@ func TestHostingListDomainsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.ListDomains()
+				ctx := context.Background()
+				return HostingApi{}.ListDomains(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -339,7 +345,8 @@ func TestHostingGetDomain(t *testing.T) {
 	defer teardown()
 
 	hostingApi := HostingApi{}
-	domain, err := hostingApi.GetDomain("exmple.com")
+	ctx := context.Background()
+	domain, err := hostingApi.GetDomain(ctx, "exmple.com")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -373,7 +380,8 @@ func TestHostingGetDomainServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetDomain("exmple.com")
+				ctx := context.Background()
+				return HostingApi{}.GetDomain(ctx, "exmple.com")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "ACCESS_DENIED",
@@ -389,7 +397,8 @@ func TestHostingGetDomainServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "39e010ed-0e93-42c3-c28f-3ffc373553d5", "errorCode": "404", "errorMessage": "Range with id 88.17.0.0_17 does not exist"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetDomain("exmple.com")
+				ctx := context.Background()
+				return HostingApi{}.GetDomain(ctx, "exmple.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "39e010ed-0e93-42c3-c28f-3ffc373553d5",
@@ -406,7 +415,8 @@ func TestHostingGetDomainServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetDomain("exmple.com")
+				ctx := context.Background()
+				return HostingApi{}.GetDomain(ctx, "exmple.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -423,7 +433,8 @@ func TestHostingGetDomainServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetDomain("exmple.com")
+				ctx := context.Background()
+				return HostingApi{}.GetDomain(ctx, "exmple.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -452,7 +463,8 @@ func TestHostingGetAvailability(t *testing.T) {
 	defer teardown()
 
 	hostingApi := HostingApi{}
-	domain, err := hostingApi.GetAvailability("exmple.com")
+	ctx := context.Background()
+	domain, err := hostingApi.GetAvailability(ctx, "exmple.com")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -473,7 +485,8 @@ func TestHostingGetAvailabilityServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetAvailability("exmple.com")
+				ctx := context.Background()
+				return HostingApi{}.GetAvailability(ctx, "exmple.com")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "ACCESS_DENIED",
@@ -489,7 +502,8 @@ func TestHostingGetAvailabilityServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "39e010ed-0e93-42c3-c28f-3ffc373553d5", "errorCode": "404", "errorMessage": "Range with id 88.17.0.0_17 does not exist"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetAvailability("exmple.com")
+				ctx := context.Background()
+				return HostingApi{}.GetAvailability(ctx, "exmple.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "39e010ed-0e93-42c3-c28f-3ffc373553d5",
@@ -506,7 +520,8 @@ func TestHostingGetAvailabilityServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetAvailability("exmple.com")
+				ctx := context.Background()
+				return HostingApi{}.GetAvailability(ctx, "exmple.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -523,7 +538,8 @@ func TestHostingGetAvailabilityServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetAvailability("exmple.com")
+				ctx := context.Background()
+				return HostingApi{}.GetAvailability(ctx, "exmple.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -564,7 +580,8 @@ func TestHostingListNameservers(t *testing.T) {
 	defer teardown()
 
 	hostingApi := HostingApi{}
-	response, err := hostingApi.ListNameservers("example.com")
+	ctx := context.Background()
+	response, err := hostingApi.ListNameservers(ctx, "example.com")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -605,7 +622,8 @@ func TestHostingListNameserversPaginateAndFilter(t *testing.T) {
 	defer teardown()
 
 	hostingApi := HostingApi{}
-	response, err := hostingApi.ListNameservers("example.com", 1)
+	ctx := context.Background()
+	response, err := hostingApi.ListNameservers(ctx, "example.com", 1)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -630,7 +648,8 @@ func TestHostingListNameserversServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.ListNameservers("example.com", 1)
+				ctx := context.Background()
+				return HostingApi{}.ListNameservers(ctx, "example.com", 1)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -647,7 +666,8 @@ func TestHostingListNameserversServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.ListNameservers("example.com", 1)
+				ctx := context.Background()
+				return HostingApi{}.ListNameservers(ctx, "example.com", 1)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -664,7 +684,8 @@ func TestHostingListNameserversServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.ListNameservers("example.com", 1)
+				ctx := context.Background()
+				return HostingApi{}.ListNameservers(ctx, "example.com", 1)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -704,7 +725,8 @@ func TestHostingUpdateNameservers(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := HostingApi{}.UpdateNameservers("example.com", []string{"ns1.example.com", "ns2.example.com"})
+	ctx := context.Background()
+	response, err := HostingApi{}.UpdateNameservers(ctx, "example.com", []string{"ns1.example.com", "ns2.example.com"})
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -730,7 +752,8 @@ func TestHostingUpdateNameserversServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateNameservers("example.com", []string{"ns1.example.com", "ns2.example.com"})
+				ctx := context.Background()
+				return HostingApi{}.UpdateNameservers(ctx, "example.com", []string{"ns1.example.com", "ns2.example.com"})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -747,7 +770,8 @@ func TestHostingUpdateNameserversServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateNameservers("example.com", []string{"ns1.example.com", "ns2.example.com"})
+				ctx := context.Background()
+				return HostingApi{}.UpdateNameservers(ctx, "example.com", []string{"ns1.example.com", "ns2.example.com"})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -764,7 +788,8 @@ func TestHostingUpdateNameserversServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateNameservers("example.com", []string{"ns1.example.com", "ns2.example.com"})
+				ctx := context.Background()
+				return HostingApi{}.UpdateNameservers(ctx, "example.com", []string{"ns1.example.com", "ns2.example.com"})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -781,7 +806,8 @@ func TestHostingUpdateNameserversServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateNameservers("example.com", []string{"ns1.example.com", "ns2.example.com"})
+				ctx := context.Background()
+				return HostingApi{}.UpdateNameservers(ctx, "example.com", []string{"ns1.example.com", "ns2.example.com"})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -817,7 +843,8 @@ func TestHostingGetGetDnsSecurity(t *testing.T) {
 	defer teardown()
 
 	hostingApi := HostingApi{}
-	resp, err := hostingApi.GetDnsSecurity("exmple.com")
+	ctx := context.Background()
+	resp, err := hostingApi.GetDnsSecurity(ctx, "exmple.com")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -841,7 +868,8 @@ func TestHostingGetGetDnsSecurityServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetDnsSecurity("exmple.com")
+				ctx := context.Background()
+				return HostingApi{}.GetDnsSecurity(ctx, "exmple.com")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "ACCESS_DENIED",
@@ -857,7 +885,8 @@ func TestHostingGetGetDnsSecurityServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "39e010ed-0e93-42c3-c28f-3ffc373553d5", "errorCode": "404", "errorMessage": "Range with id 88.17.0.0_17 does not exist"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetDnsSecurity("exmple.com")
+				ctx := context.Background()
+				return HostingApi{}.GetDnsSecurity(ctx, "exmple.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "39e010ed-0e93-42c3-c28f-3ffc373553d5",
@@ -874,7 +903,8 @@ func TestHostingGetGetDnsSecurityServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetDnsSecurity("exmple.com")
+				ctx := context.Background()
+				return HostingApi{}.GetDnsSecurity(ctx, "exmple.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -891,7 +921,8 @@ func TestHostingGetGetDnsSecurityServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetDnsSecurity("exmple.com")
+				ctx := context.Background()
+				return HostingApi{}.GetDnsSecurity(ctx, "exmple.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -913,7 +944,8 @@ func TestHostingUpdateDnsSecurity(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := HostingApi{}.UpdateDnsSecurity("example.com", map[string]interface{}{"status": "ENABLED"})
+	ctx := context.Background()
+	response, err := HostingApi{}.UpdateDnsSecurity(ctx, "example.com", map[string]interface{}{"status": "ENABLED"})
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -931,7 +963,8 @@ func TestHostingUpdateDnsSecurityServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateDnsSecurity("example.com", map[string]interface{}{"status": "ENABLED"})
+				ctx := context.Background()
+				return HostingApi{}.UpdateDnsSecurity(ctx, "example.com", map[string]interface{}{"status": "ENABLED"})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -948,7 +981,8 @@ func TestHostingUpdateDnsSecurityServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateDnsSecurity("example.com", map[string]interface{}{"status": "ENABLED"})
+				ctx := context.Background()
+				return HostingApi{}.UpdateDnsSecurity(ctx, "example.com", map[string]interface{}{"status": "ENABLED"})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -965,7 +999,8 @@ func TestHostingUpdateDnsSecurityServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateDnsSecurity("example.com", map[string]interface{}{"status": "ENABLED"})
+				ctx := context.Background()
+				return HostingApi{}.UpdateDnsSecurity(ctx, "example.com", map[string]interface{}{"status": "ENABLED"})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -982,7 +1017,8 @@ func TestHostingUpdateDnsSecurityServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateDnsSecurity("example.com", map[string]interface{}{"status": "ENABLED"})
+				ctx := context.Background()
+				return HostingApi{}.UpdateDnsSecurity(ctx, "example.com", map[string]interface{}{"status": "ENABLED"})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1059,7 +1095,8 @@ func TestHostingListResourceRecordSets(t *testing.T) {
 	defer teardown()
 
 	hostingApi := HostingApi{}
-	response, err := hostingApi.ListResourceRecordSets("example.com")
+	ctx := context.Background()
+	response, err := hostingApi.ListResourceRecordSets(ctx, "example.com")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -1142,7 +1179,8 @@ func TestHostingListResourceRecordSetsPaginateAndFilter(t *testing.T) {
 	defer teardown()
 
 	hostingApi := HostingApi{}
-	response, err := hostingApi.ListResourceRecordSets("example.com", 1)
+	ctx := context.Background()
+	response, err := hostingApi.ListResourceRecordSets(ctx, "example.com", 1)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -1179,7 +1217,8 @@ func TestHostingListResourceRecordSetsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.ListResourceRecordSets("example.com")
+				ctx := context.Background()
+				return HostingApi{}.ListResourceRecordSets(ctx, "example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1196,7 +1235,8 @@ func TestHostingListResourceRecordSetsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.ListResourceRecordSets("example.com")
+				ctx := context.Background()
+				return HostingApi{}.ListResourceRecordSets(ctx, "example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1213,7 +1253,8 @@ func TestHostingListResourceRecordSetsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.ListResourceRecordSets("example.com")
+				ctx := context.Background()
+				return HostingApi{}.ListResourceRecordSets(ctx, "example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1251,7 +1292,8 @@ func TestHostingCreateResourceRecordSet(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := HostingApi{}.CreateResourceRecordSet("example.com", map[string]interface{}{
+	ctx := context.Background()
+	resp, err := HostingApi{}.CreateResourceRecordSet(ctx, "example.com", map[string]interface{}{
 		"name":    "example.com.",
 		"type":    "A",
 		"ttl":     3600,
@@ -1282,7 +1324,8 @@ func TestHostingCreateResourceRecordSetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.CreateResourceRecordSet("example.com", map[string]interface{}{
+				ctx := context.Background()
+				return HostingApi{}.CreateResourceRecordSet(ctx, "example.com", map[string]interface{}{
 					"name":    "example.com.",
 					"type":    "A",
 					"ttl":     3600,
@@ -1304,7 +1347,8 @@ func TestHostingCreateResourceRecordSetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.CreateResourceRecordSet("example.com", map[string]interface{}{
+				ctx := context.Background()
+				return HostingApi{}.CreateResourceRecordSet(ctx, "example.com", map[string]interface{}{
 					"name":    "example.com.",
 					"type":    "A",
 					"ttl":     3600,
@@ -1326,7 +1370,8 @@ func TestHostingCreateResourceRecordSetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.CreateResourceRecordSet("example.com", map[string]interface{}{
+				ctx := context.Background()
+				return HostingApi{}.CreateResourceRecordSet(ctx, "example.com", map[string]interface{}{
 					"name":    "example.com.",
 					"type":    "A",
 					"ttl":     3600,
@@ -1348,7 +1393,8 @@ func TestHostingCreateResourceRecordSetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.CreateResourceRecordSet("example.com", map[string]interface{}{
+				ctx := context.Background()
+				return HostingApi{}.CreateResourceRecordSet(ctx, "example.com", map[string]interface{}{
 					"name":    "example.com.",
 					"type":    "A",
 					"ttl":     3600,
@@ -1373,7 +1419,8 @@ func TestHostingDeleteResourceRecordSets(t *testing.T) {
 	})
 	defer teardown()
 
-	err := HostingApi{}.DeleteResourceRecordSets("example.com")
+	ctx := context.Background()
+	err := HostingApi{}.DeleteResourceRecordSets(ctx, "example.com")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -1390,7 +1437,8 @@ func TestHostingDeleteResourceRecordSetsServerError(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, HostingApi{}.DeleteResourceRecordSet("example.com", "example.com.", "A")
+				ctx := context.Background()
+				return nil, HostingApi{}.DeleteResourceRecordSet(ctx, "example.com", "example.com.", "A")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1407,7 +1455,8 @@ func TestHostingDeleteResourceRecordSetsServerError(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, HostingApi{}.DeleteResourceRecordSet("example.com", "example.com.", "A")
+				ctx := context.Background()
+				return nil, HostingApi{}.DeleteResourceRecordSet(ctx, "example.com", "example.com.", "A")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1424,7 +1473,8 @@ func TestHostingDeleteResourceRecordSetsServerError(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, HostingApi{}.DeleteResourceRecordSet("example.com", "example.com.", "A")
+				ctx := context.Background()
+				return nil, HostingApi{}.DeleteResourceRecordSet(ctx, "example.com", "example.com.", "A")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1441,7 +1491,8 @@ func TestHostingDeleteResourceRecordSetsServerError(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, HostingApi{}.DeleteResourceRecordSet("example.com", "example.com.", "A")
+				ctx := context.Background()
+				return nil, HostingApi{}.DeleteResourceRecordSet(ctx, "example.com", "example.com.", "A")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1479,7 +1530,8 @@ func TestHostingGetResourceRecordSet(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := HostingApi{}.GetResourceRecordSet("exmple.com", "example.com.", "A")
+	ctx := context.Background()
+	resp, err := HostingApi{}.GetResourceRecordSet(ctx, "exmple.com", "example.com.", "A")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -1506,7 +1558,8 @@ func TestHostingGetResourceRecordSetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetResourceRecordSet("exmple.com", "example.com.", "A")
+				ctx := context.Background()
+				return HostingApi{}.GetResourceRecordSet(ctx, "exmple.com", "example.com.", "A")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "ACCESS_DENIED",
@@ -1522,7 +1575,8 @@ func TestHostingGetResourceRecordSetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "39e010ed-0e93-42c3-c28f-3ffc373553d5", "errorCode": "404", "errorMessage": "Range with id 88.17.0.0_17 does not exist"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetResourceRecordSet("exmple.com", "example.com.", "A")
+				ctx := context.Background()
+				return HostingApi{}.GetResourceRecordSet(ctx, "exmple.com", "example.com.", "A")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "39e010ed-0e93-42c3-c28f-3ffc373553d5",
@@ -1539,7 +1593,8 @@ func TestHostingGetResourceRecordSetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetResourceRecordSet("exmple.com", "example.com.", "A")
+				ctx := context.Background()
+				return HostingApi{}.GetResourceRecordSet(ctx, "exmple.com", "example.com.", "A")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1556,7 +1611,8 @@ func TestHostingGetResourceRecordSetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetResourceRecordSet("exmple.com", "example.com.", "A")
+				ctx := context.Background()
+				return HostingApi{}.GetResourceRecordSet(ctx, "exmple.com", "example.com.", "A")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1592,7 +1648,8 @@ func TestHostingUpdateResourceRecordSet(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := HostingApi{}.UpdateResourceRecordSet("exmple.com", "example.com.", "A", []string{"85.17.150.54"}, 4200)
+	ctx := context.Background()
+	resp, err := HostingApi{}.UpdateResourceRecordSet(ctx, "exmple.com", "example.com.", "A", []string{"85.17.150.54"}, 4200)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -1617,7 +1674,8 @@ func TestHostingUpdateResourceRecordSetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateResourceRecordSet("exmple.com", "example.com.", "A", []string{"85.17.150.54"}, 4200)
+				ctx := context.Background()
+				return HostingApi{}.UpdateResourceRecordSet(ctx, "exmple.com", "example.com.", "A", []string{"85.17.150.54"}, 4200)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1634,7 +1692,8 @@ func TestHostingUpdateResourceRecordSetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateResourceRecordSet("exmple.com", "example.com.", "A", []string{"85.17.150.54"}, 4200)
+				ctx := context.Background()
+				return HostingApi{}.UpdateResourceRecordSet(ctx, "exmple.com", "example.com.", "A", []string{"85.17.150.54"}, 4200)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1651,7 +1710,8 @@ func TestHostingUpdateResourceRecordSetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateResourceRecordSet("exmple.com", "example.com.", "A", []string{"85.17.150.54"}, 4200)
+				ctx := context.Background()
+				return HostingApi{}.UpdateResourceRecordSet(ctx, "exmple.com", "example.com.", "A", []string{"85.17.150.54"}, 4200)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1668,7 +1728,8 @@ func TestHostingUpdateResourceRecordSetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateResourceRecordSet("exmple.com", "example.com.", "A", []string{"85.17.150.54"}, 4200)
+				ctx := context.Background()
+				return HostingApi{}.UpdateResourceRecordSet(ctx, "exmple.com", "example.com.", "A", []string{"85.17.150.54"}, 4200)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1688,7 +1749,8 @@ func TestHostingDeleteResourceRecordSet(t *testing.T) {
 	})
 	defer teardown()
 
-	err := HostingApi{}.DeleteResourceRecordSet("example.com", "example.com.", "A")
+	ctx := context.Background()
+	err := HostingApi{}.DeleteResourceRecordSet(ctx, "example.com", "example.com.", "A")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -1705,7 +1767,8 @@ func TestHostingDeleteResourceRecordSetsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, HostingApi{}.DeleteResourceRecordSets("example.com")
+				ctx := context.Background()
+				return nil, HostingApi{}.DeleteResourceRecordSets(ctx, "example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1722,7 +1785,8 @@ func TestHostingDeleteResourceRecordSetsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, HostingApi{}.DeleteResourceRecordSets("example.com")
+				ctx := context.Background()
+				return nil, HostingApi{}.DeleteResourceRecordSets(ctx, "example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1739,7 +1803,8 @@ func TestHostingDeleteResourceRecordSetsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, HostingApi{}.DeleteResourceRecordSets("example.com")
+				ctx := context.Background()
+				return nil, HostingApi{}.DeleteResourceRecordSets(ctx, "example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1756,7 +1821,8 @@ func TestHostingDeleteResourceRecordSetsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, HostingApi{}.DeleteResourceRecordSets("example.com")
+				ctx := context.Background()
+				return nil, HostingApi{}.DeleteResourceRecordSets(ctx, "example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1778,7 +1844,8 @@ func TestHostingValidateResourceRecordSet(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := HostingApi{}.ValidateResourceRecordSet("example.com", "example.com.", "A", []string{"127.0.0.1"}, 3600)
+	ctx := context.Background()
+	resp, err := HostingApi{}.ValidateResourceRecordSet(ctx, "example.com", "example.com.", "A", []string{"127.0.0.1"}, 3600)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -1796,7 +1863,8 @@ func TestHostingValidateResourceRecordSetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.ValidateResourceRecordSet("example.com", "example.com.", "A", []string{"127.0.0.1"}, 3600)
+				ctx := context.Background()
+				return HostingApi{}.ValidateResourceRecordSet(ctx, "example.com", "example.com.", "A", []string{"127.0.0.1"}, 3600)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1813,7 +1881,8 @@ func TestHostingValidateResourceRecordSetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.ValidateResourceRecordSet("example.com", "example.com.", "A", []string{"127.0.0.1"}, 3600)
+				ctx := context.Background()
+				return HostingApi{}.ValidateResourceRecordSet(ctx, "example.com", "example.com.", "A", []string{"127.0.0.1"}, 3600)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1830,7 +1899,8 @@ func TestHostingValidateResourceRecordSetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.ValidateResourceRecordSet("example.com", "example.com.", "A", []string{"127.0.0.1"}, 3600)
+				ctx := context.Background()
+				return HostingApi{}.ValidateResourceRecordSet(ctx, "example.com", "example.com.", "A", []string{"127.0.0.1"}, 3600)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1847,7 +1917,8 @@ func TestHostingValidateResourceRecordSetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.ValidateResourceRecordSet("example.com", "example.com.", "A", []string{"127.0.0.1"}, 3600)
+				ctx := context.Background()
+				return HostingApi{}.ValidateResourceRecordSet(ctx, "example.com", "example.com.", "A", []string{"127.0.0.1"}, 3600)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1879,7 +1950,8 @@ func TestHostingListCatchAll(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := HostingApi{}.ListCatchAll("example.com")
+	ctx := context.Background()
+	resp, err := HostingApi{}.ListCatchAll(ctx, "example.com")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -1901,7 +1973,8 @@ func TestHostingListCatchAllServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.ListCatchAll("example.com")
+				ctx := context.Background()
+				return HostingApi{}.ListCatchAll(ctx, "example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1918,7 +1991,8 @@ func TestHostingListCatchAllServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.ListCatchAll("example.com")
+				ctx := context.Background()
+				return HostingApi{}.ListCatchAll(ctx, "example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1935,7 +2009,8 @@ func TestHostingListCatchAllServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.ListCatchAll("example.com")
+				ctx := context.Background()
+				return HostingApi{}.ListCatchAll(ctx, "example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1967,7 +2042,8 @@ func TestHostingUpdateOrCreateCatchAll(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := HostingApi{}.UpdateCatchAll("exmple.com", map[string]interface{}{
+	ctx := context.Background()
+	resp, err := HostingApi{}.UpdateCatchAll(ctx, "exmple.com", map[string]interface{}{
 		"destination":        "destination@example.org",
 		"spamChecksEnabled":  true,
 		"virusChecksEnabled": false,
@@ -1994,7 +2070,8 @@ func TestHostingUpdateOrCreateCatchAllServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateCatchAll("exmple.com", map[string]interface{}{
+				ctx := context.Background()
+				return HostingApi{}.UpdateCatchAll(ctx, "exmple.com", map[string]interface{}{
 					"destination":        "destination@example.org",
 					"spamChecksEnabled":  true,
 					"virusChecksEnabled": false,
@@ -2015,7 +2092,8 @@ func TestHostingUpdateOrCreateCatchAllServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateCatchAll("exmple.com", map[string]interface{}{
+				ctx := context.Background()
+				return HostingApi{}.UpdateCatchAll(ctx, "exmple.com", map[string]interface{}{
 					"destination":        "destination@example.org",
 					"spamChecksEnabled":  true,
 					"virusChecksEnabled": false,
@@ -2036,7 +2114,8 @@ func TestHostingUpdateOrCreateCatchAllServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateCatchAll("exmple.com", map[string]interface{}{
+				ctx := context.Background()
+				return HostingApi{}.UpdateCatchAll(ctx, "exmple.com", map[string]interface{}{
 					"destination":        "destination@example.org",
 					"spamChecksEnabled":  true,
 					"virusChecksEnabled": false,
@@ -2057,7 +2136,8 @@ func TestHostingUpdateOrCreateCatchAllServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateCatchAll("exmple.com", map[string]interface{}{
+				ctx := context.Background()
+				return HostingApi{}.UpdateCatchAll(ctx, "exmple.com", map[string]interface{}{
 					"destination":        "destination@example.org",
 					"spamChecksEnabled":  true,
 					"virusChecksEnabled": false,
@@ -2081,7 +2161,8 @@ func TestHostingDeleteCatchAll(t *testing.T) {
 	})
 	defer teardown()
 
-	err := HostingApi{}.DeleteCatchAll("example.com")
+	ctx := context.Background()
+	err := HostingApi{}.DeleteCatchAll(ctx, "example.com")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -2098,7 +2179,8 @@ func TestHostingDeleteCatchAllsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, HostingApi{}.DeleteCatchAll("example.com")
+				ctx := context.Background()
+				return nil, HostingApi{}.DeleteCatchAll(ctx, "example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2115,7 +2197,8 @@ func TestHostingDeleteCatchAllsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, HostingApi{}.DeleteCatchAll("example.com")
+				ctx := context.Background()
+				return nil, HostingApi{}.DeleteCatchAll(ctx, "example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2132,7 +2215,8 @@ func TestHostingDeleteCatchAllsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, HostingApi{}.DeleteCatchAll("example.com")
+				ctx := context.Background()
+				return nil, HostingApi{}.DeleteCatchAll(ctx, "example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2149,7 +2233,8 @@ func TestHostingDeleteCatchAllsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, HostingApi{}.DeleteCatchAll("example.com")
+				ctx := context.Background()
+				return nil, HostingApi{}.DeleteCatchAll(ctx, "example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2215,7 +2300,8 @@ func TestHostingListEmailAliases(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := HostingApi{}.ListEmailAliases("example.com")
+	ctx := context.Background()
+	response, err := HostingApi{}.ListEmailAliases(ctx, "example.com")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -2284,7 +2370,8 @@ func TestHostingListEmailAliasesPaginateAndFilter(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := HostingApi{}.ListEmailAliases("example.com", 1)
+	ctx := context.Background()
+	response, err := HostingApi{}.ListEmailAliases(ctx, "example.com", 1)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -2316,7 +2403,8 @@ func TestHostingListEmailAliasesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.ListEmailAliases("example.com")
+				ctx := context.Background()
+				return HostingApi{}.ListEmailAliases(ctx, "example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2333,7 +2421,8 @@ func TestHostingListEmailAliasesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.ListEmailAliases("example.com")
+				ctx := context.Background()
+				return HostingApi{}.ListEmailAliases(ctx, "example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2350,7 +2439,8 @@ func TestHostingListEmailAliasesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.ListEmailAliases("example.com")
+				ctx := context.Background()
+				return HostingApi{}.ListEmailAliases(ctx, "example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2384,7 +2474,8 @@ func TestHostingCreateEmailAlias(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := HostingApi{}.CreateEmailAlias("example.com", map[string]interface{}{
+	ctx := context.Background()
+	resp, err := HostingApi{}.CreateEmailAlias(ctx, "example.com", map[string]interface{}{
 		"active":             true,
 		"destination":        "destination@example.com",
 		"source":             "source@example.com",
@@ -2414,7 +2505,8 @@ func TestHostingCreateEmailAliasServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.CreateEmailAlias("example.com", map[string]interface{}{
+				ctx := context.Background()
+				return HostingApi{}.CreateEmailAlias(ctx, "example.com", map[string]interface{}{
 					"active":             true,
 					"destination":        "destination@example.com",
 					"source":             "source@example.com",
@@ -2437,7 +2529,8 @@ func TestHostingCreateEmailAliasServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.CreateEmailAlias("example.com", map[string]interface{}{
+				ctx := context.Background()
+				return HostingApi{}.CreateEmailAlias(ctx, "example.com", map[string]interface{}{
 					"active":             true,
 					"destination":        "destination@example.com",
 					"source":             "source@example.com",
@@ -2460,7 +2553,8 @@ func TestHostingCreateEmailAliasServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.CreateEmailAlias("example.com", map[string]interface{}{
+				ctx := context.Background()
+				return HostingApi{}.CreateEmailAlias(ctx, "example.com", map[string]interface{}{
 					"active":             true,
 					"destination":        "destination@example.com",
 					"source":             "source@example.com",
@@ -2483,7 +2577,8 @@ func TestHostingCreateEmailAliasServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.CreateEmailAlias("example.com", map[string]interface{}{
+				ctx := context.Background()
+				return HostingApi{}.CreateEmailAlias(ctx, "example.com", map[string]interface{}{
 					"active":             true,
 					"destination":        "destination@example.com",
 					"source":             "source@example.com",
@@ -2523,7 +2618,8 @@ func TestHostingGetEmailAlias(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := HostingApi{}.GetEmailAlias("example.com", "source@example.com", "destination@example.com")
+	ctx := context.Background()
+	resp, err := HostingApi{}.GetEmailAlias(ctx, "example.com", "source@example.com", "destination@example.com")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -2547,7 +2643,8 @@ func TestHostingGetEmailAliasServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetEmailAlias("example.com", "source@example.com", "destination@example.com")
+				ctx := context.Background()
+				return HostingApi{}.GetEmailAlias(ctx, "example.com", "source@example.com", "destination@example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2564,7 +2661,8 @@ func TestHostingGetEmailAliasServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetEmailAlias("example.com", "source@example.com", "destination@example.com")
+				ctx := context.Background()
+				return HostingApi{}.GetEmailAlias(ctx, "example.com", "source@example.com", "destination@example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2581,7 +2679,8 @@ func TestHostingGetEmailAliasServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetEmailAlias("example.com", "source@example.com", "destination@example.com")
+				ctx := context.Background()
+				return HostingApi{}.GetEmailAlias(ctx, "example.com", "source@example.com", "destination@example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2598,7 +2697,8 @@ func TestHostingGetEmailAliasServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetEmailAlias("example.com", "source@example.com", "destination@example.com")
+				ctx := context.Background()
+				return HostingApi{}.GetEmailAlias(ctx, "example.com", "source@example.com", "destination@example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2632,7 +2732,8 @@ func TestHostingUpdateEmailAlias(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := HostingApi{}.UpdateEmailAlias("example.com", "source@example.com", "destination@example.com", map[string]bool{
+	ctx := context.Background()
+	resp, err := HostingApi{}.UpdateEmailAlias(ctx, "example.com", "source@example.com", "destination@example.com", map[string]bool{
 		"active":             true,
 		"spamChecksEnabled":  true,
 		"virusChecksEnabled": true,
@@ -2660,7 +2761,8 @@ func TestHostingUpdateEmailAliasServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateEmailAlias("example.com", "source@example.com", "destination@example.com", map[string]bool{
+				ctx := context.Background()
+				return HostingApi{}.UpdateEmailAlias(ctx, "example.com", "source@example.com", "destination@example.com", map[string]bool{
 					"active":             true,
 					"spamChecksEnabled":  true,
 					"virusChecksEnabled": true,
@@ -2681,7 +2783,8 @@ func TestHostingUpdateEmailAliasServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateEmailAlias("example.com", "source@example.com", "destination@example.com", map[string]bool{
+				ctx := context.Background()
+				return HostingApi{}.UpdateEmailAlias(ctx, "example.com", "source@example.com", "destination@example.com", map[string]bool{
 					"active":             true,
 					"spamChecksEnabled":  true,
 					"virusChecksEnabled": true,
@@ -2702,7 +2805,8 @@ func TestHostingUpdateEmailAliasServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateEmailAlias("example.com", "source@example.com", "destination@example.com", map[string]bool{
+				ctx := context.Background()
+				return HostingApi{}.UpdateEmailAlias(ctx, "example.com", "source@example.com", "destination@example.com", map[string]bool{
 					"active":             true,
 					"spamChecksEnabled":  true,
 					"virusChecksEnabled": true,
@@ -2723,7 +2827,8 @@ func TestHostingUpdateEmailAliasServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateEmailAlias("example.com", "source@example.com", "destination@example.com", map[string]bool{
+				ctx := context.Background()
+				return HostingApi{}.UpdateEmailAlias(ctx, "example.com", "source@example.com", "destination@example.com", map[string]bool{
 					"active":             true,
 					"spamChecksEnabled":  true,
 					"virusChecksEnabled": true,
@@ -2747,7 +2852,8 @@ func TestHostingDeleteEmailAlias(t *testing.T) {
 	})
 	defer teardown()
 
-	err := HostingApi{}.DeleteEmailAlias("example.com", "source", "dest")
+	ctx := context.Background()
+	err := HostingApi{}.DeleteEmailAlias(ctx, "example.com", "source", "dest")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -2764,7 +2870,8 @@ func TestHostingDeleteEmailAliasServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, HostingApi{}.DeleteEmailAlias("example.com", "source", "dest")
+				ctx := context.Background()
+				return nil, HostingApi{}.DeleteEmailAlias(ctx, "example.com", "source", "dest")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2781,7 +2888,8 @@ func TestHostingDeleteEmailAliasServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, HostingApi{}.DeleteEmailAlias("example.com", "source", "dest")
+				ctx := context.Background()
+				return nil, HostingApi{}.DeleteEmailAlias(ctx, "example.com", "source", "dest")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2798,7 +2906,8 @@ func TestHostingDeleteEmailAliasServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, HostingApi{}.DeleteEmailAlias("example.com", "source", "dest")
+				ctx := context.Background()
+				return nil, HostingApi{}.DeleteEmailAlias(ctx, "example.com", "source", "dest")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2815,7 +2924,8 @@ func TestHostingDeleteEmailAliasServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, HostingApi{}.DeleteEmailAlias("example.com", "source", "dest")
+				ctx := context.Background()
+				return nil, HostingApi{}.DeleteEmailAlias(ctx, "example.com", "source", "dest")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2881,7 +2991,8 @@ func TestHostingListDomainForwards(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := HostingApi{}.ListDomainForwards("example.com")
+	ctx := context.Background()
+	response, err := HostingApi{}.ListDomainForwards(ctx, "example.com")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -2950,7 +3061,8 @@ func TestHostingListDomainForwardsPaginateAndFilter(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := HostingApi{}.ListDomainForwards("example.com", 1)
+	ctx := context.Background()
+	response, err := HostingApi{}.ListDomainForwards(ctx, "example.com", 1)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -2982,7 +3094,8 @@ func TestHostingListDomainForwardsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.ListDomainForwards("example.com")
+				ctx := context.Background()
+				return HostingApi{}.ListDomainForwards(ctx, "example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -2999,7 +3112,8 @@ func TestHostingListDomainForwardsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.ListDomainForwards("example.com")
+				ctx := context.Background()
+				return HostingApi{}.ListDomainForwards(ctx, "example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3016,7 +3130,8 @@ func TestHostingListDomainForwardsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.ListDomainForwards("example.com")
+				ctx := context.Background()
+				return HostingApi{}.ListDomainForwards(ctx, "example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3090,7 +3205,8 @@ func TestHostingListMailBoxes(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := HostingApi{}.ListMailBoxes("example.com")
+	ctx := context.Background()
+	response, err := HostingApi{}.ListMailBoxes(ctx, "example.com")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -3171,7 +3287,8 @@ func TestHostingListMailBoxesPaginateAndFilter(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := HostingApi{}.ListMailBoxes("example.com", 1)
+	ctx := context.Background()
+	response, err := HostingApi{}.ListMailBoxes(ctx, "example.com", 1)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -3207,7 +3324,8 @@ func TestHostingListMailBoxesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.ListMailBoxes("example.com")
+				ctx := context.Background()
+				return HostingApi{}.ListMailBoxes(ctx, "example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3224,7 +3342,8 @@ func TestHostingListMailBoxesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.ListMailBoxes("example.com")
+				ctx := context.Background()
+				return HostingApi{}.ListMailBoxes(ctx, "example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3241,7 +3360,8 @@ func TestHostingListMailBoxesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.ListMailBoxes("example.com")
+				ctx := context.Background()
+				return HostingApi{}.ListMailBoxes(ctx, "example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3293,7 +3413,8 @@ func TestHostingCreateMailBox(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := HostingApi{}.CreateMailBox("example.com", map[string]interface{}{
+	ctx := context.Background()
+	resp, err := HostingApi{}.CreateMailBox(ctx, "example.com", map[string]interface{}{
 		"emailAddress":       "mailbox@example.com",
 		"active":             true,
 		"password":           "CHANGETHIS",
@@ -3330,7 +3451,8 @@ func TestHostingCreateMailBoxServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.CreateMailBox("example.com", map[string]interface{}{
+				ctx := context.Background()
+				return HostingApi{}.CreateMailBox(ctx, "example.com", map[string]interface{}{
 					"emailAddress":       "mailbox@example.com",
 					"active":             true,
 					"password":           "CHANGETHIS",
@@ -3354,7 +3476,8 @@ func TestHostingCreateMailBoxServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.CreateMailBox("example.com", map[string]interface{}{
+				ctx := context.Background()
+				return HostingApi{}.CreateMailBox(ctx, "example.com", map[string]interface{}{
 					"emailAddress":       "mailbox@example.com",
 					"active":             true,
 					"password":           "CHANGETHIS",
@@ -3378,7 +3501,8 @@ func TestHostingCreateMailBoxServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.CreateMailBox("example.com", map[string]interface{}{
+				ctx := context.Background()
+				return HostingApi{}.CreateMailBox(ctx, "example.com", map[string]interface{}{
 					"emailAddress":       "mailbox@example.com",
 					"active":             true,
 					"password":           "CHANGETHIS",
@@ -3402,7 +3526,8 @@ func TestHostingCreateMailBoxServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.CreateMailBox("example.com", map[string]interface{}{
+				ctx := context.Background()
+				return HostingApi{}.CreateMailBox(ctx, "example.com", map[string]interface{}{
 					"emailAddress":       "mailbox@example.com",
 					"active":             true,
 					"password":           "CHANGETHIS",
@@ -3461,7 +3586,8 @@ func TestHostingGetMailBox(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := HostingApi{}.GetMailBox("example.com", "mailbox@example.com")
+	ctx := context.Background()
+	resp, err := HostingApi{}.GetMailBox(ctx, "example.com", "mailbox@example.com")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -3491,7 +3617,8 @@ func TestHostingGetMailBoxServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetMailBox("example.com", "mailbox@example.com")
+				ctx := context.Background()
+				return HostingApi{}.GetMailBox(ctx, "example.com", "mailbox@example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3508,7 +3635,8 @@ func TestHostingGetMailBoxServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetMailBox("example.com", "mailbox@example.com")
+				ctx := context.Background()
+				return HostingApi{}.GetMailBox(ctx, "example.com", "mailbox@example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3525,7 +3653,8 @@ func TestHostingGetMailBoxServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetMailBox("example.com", "mailbox@example.com")
+				ctx := context.Background()
+				return HostingApi{}.GetMailBox(ctx, "example.com", "mailbox@example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3542,7 +3671,8 @@ func TestHostingGetMailBoxServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetMailBox("example.com", "mailbox@example.com")
+				ctx := context.Background()
+				return HostingApi{}.GetMailBox(ctx, "example.com", "mailbox@example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3594,7 +3724,8 @@ func TestHostingUpdateMailBox(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := HostingApi{}.UpdateMailBox("example.com", "mailbox@example.com", map[string]interface{}{
+	ctx := context.Background()
+	resp, err := HostingApi{}.UpdateMailBox(ctx, "example.com", "mailbox@example.com", map[string]interface{}{
 		"emailAddress":       "mailbox@example.com",
 		"active":             true,
 		"password":           "CHANGETHIS",
@@ -3631,7 +3762,8 @@ func TestHostingUpdateMailBoxServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateMailBox("example.com", "mailbox@example.com", map[string]interface{}{
+				ctx := context.Background()
+				return HostingApi{}.UpdateMailBox(ctx, "example.com", "mailbox@example.com", map[string]interface{}{
 					"emailAddress":       "mailbox@example.com",
 					"active":             true,
 					"password":           "CHANGETHIS",
@@ -3655,7 +3787,8 @@ func TestHostingUpdateMailBoxServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateMailBox("example.com", "mailbox@example.com", map[string]interface{}{
+				ctx := context.Background()
+				return HostingApi{}.UpdateMailBox(ctx, "example.com", "mailbox@example.com", map[string]interface{}{
 					"emailAddress":       "mailbox@example.com",
 					"active":             true,
 					"password":           "CHANGETHIS",
@@ -3679,7 +3812,8 @@ func TestHostingUpdateMailBoxServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateMailBox("example.com", "mailbox@example.com", map[string]interface{}{
+				ctx := context.Background()
+				return HostingApi{}.UpdateMailBox(ctx, "example.com", "mailbox@example.com", map[string]interface{}{
 					"emailAddress":       "mailbox@example.com",
 					"active":             true,
 					"password":           "CHANGETHIS",
@@ -3703,7 +3837,8 @@ func TestHostingUpdateMailBoxServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateMailBox("example.com", "mailbox@example.com", map[string]interface{}{
+				ctx := context.Background()
+				return HostingApi{}.UpdateMailBox(ctx, "example.com", "mailbox@example.com", map[string]interface{}{
 					"emailAddress":       "mailbox@example.com",
 					"active":             true,
 					"password":           "CHANGETHIS",
@@ -3730,7 +3865,8 @@ func TestHostingDeleteMailBox(t *testing.T) {
 	})
 	defer teardown()
 
-	err := HostingApi{}.DeleteMailBox("example.com", "info@example.com")
+	ctx := context.Background()
+	err := HostingApi{}.DeleteMailBox(ctx, "example.com", "info@example.com")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -3747,7 +3883,8 @@ func TestHostingDeleteMailBoxServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, HostingApi{}.DeleteMailBox("example.com", "info@example.com")
+				ctx := context.Background()
+				return nil, HostingApi{}.DeleteMailBox(ctx, "example.com", "info@example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3764,7 +3901,8 @@ func TestHostingDeleteMailBoxServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, HostingApi{}.DeleteMailBox("example.com", "info@example.com")
+				ctx := context.Background()
+				return nil, HostingApi{}.DeleteMailBox(ctx, "example.com", "info@example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3781,7 +3919,8 @@ func TestHostingDeleteMailBoxServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, HostingApi{}.DeleteMailBox("example.com", "info@example.com")
+				ctx := context.Background()
+				return nil, HostingApi{}.DeleteMailBox(ctx, "example.com", "info@example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3798,7 +3937,8 @@ func TestHostingDeleteMailBoxServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, HostingApi{}.DeleteMailBox("example.com", "info@example.com")
+				ctx := context.Background()
+				return nil, HostingApi{}.DeleteMailBox(ctx, "example.com", "info@example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3830,7 +3970,8 @@ func TestHostingGetAutoResponder(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := HostingApi{}.GetAutoResponder("example.com", "mailbox@example.com")
+	ctx := context.Background()
+	resp, err := HostingApi{}.GetAutoResponder(ctx, "example.com", "mailbox@example.com")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -3852,7 +3993,8 @@ func TestHostingGetAutoResponderServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetAutoResponder("example.com", "mailbox@example.com")
+				ctx := context.Background()
+				return HostingApi{}.GetAutoResponder(ctx, "example.com", "mailbox@example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3869,7 +4011,8 @@ func TestHostingGetAutoResponderServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetAutoResponder("example.com", "mailbox@example.com")
+				ctx := context.Background()
+				return HostingApi{}.GetAutoResponder(ctx, "example.com", "mailbox@example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3886,7 +4029,8 @@ func TestHostingGetAutoResponderServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetAutoResponder("example.com", "mailbox@example.com")
+				ctx := context.Background()
+				return HostingApi{}.GetAutoResponder(ctx, "example.com", "mailbox@example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3903,7 +4047,8 @@ func TestHostingGetAutoResponderServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetAutoResponder("example.com", "mailbox@example.com")
+				ctx := context.Background()
+				return HostingApi{}.GetAutoResponder(ctx, "example.com", "mailbox@example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -3935,7 +4080,8 @@ func TestHostingUpdateOrCreateAutoResponder(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := HostingApi{}.UpdateAutoResponder("example.com", "mailbox@example.com", map[string]interface{}{
+	ctx := context.Background()
+	resp, err := HostingApi{}.UpdateAutoResponder(ctx, "example.com", "mailbox@example.com", map[string]interface{}{
 		"active":  true,
 		"body":    "I will be out of office until 14-12-2020. Please contact the reception desk for urgent matters.",
 		"subject": "Out of office",
@@ -3961,7 +4107,8 @@ func TestHostingUpdateOrCreateAutoResponderServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateAutoResponder("example.com", "mailbox@example.com", map[string]interface{}{
+				ctx := context.Background()
+				return HostingApi{}.UpdateAutoResponder(ctx, "example.com", "mailbox@example.com", map[string]interface{}{
 					"active":  true,
 					"body":    "I will be out of office until 14-12-2020. Please contact the reception desk for urgent matters.",
 					"subject": "Out of office",
@@ -3982,7 +4129,8 @@ func TestHostingUpdateOrCreateAutoResponderServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateAutoResponder("example.com", "mailbox@example.com", map[string]interface{}{
+				ctx := context.Background()
+				return HostingApi{}.UpdateAutoResponder(ctx, "example.com", "mailbox@example.com", map[string]interface{}{
 					"active":  true,
 					"body":    "I will be out of office until 14-12-2020. Please contact the reception desk for urgent matters.",
 					"subject": "Out of office",
@@ -4003,7 +4151,8 @@ func TestHostingUpdateOrCreateAutoResponderServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateAutoResponder("example.com", "mailbox@example.com", map[string]interface{}{
+				ctx := context.Background()
+				return HostingApi{}.UpdateAutoResponder(ctx, "example.com", "mailbox@example.com", map[string]interface{}{
 					"active":  true,
 					"body":    "I will be out of office until 14-12-2020. Please contact the reception desk for urgent matters.",
 					"subject": "Out of office",
@@ -4024,7 +4173,8 @@ func TestHostingUpdateOrCreateAutoResponderServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateAutoResponder("example.com", "mailbox@example.com", map[string]interface{}{
+				ctx := context.Background()
+				return HostingApi{}.UpdateAutoResponder(ctx, "example.com", "mailbox@example.com", map[string]interface{}{
 					"active":  true,
 					"body":    "I will be out of office until 14-12-2020. Please contact the reception desk for urgent matters.",
 					"subject": "Out of office",
@@ -4048,7 +4198,8 @@ func TestHostingDeleteAutoResponder(t *testing.T) {
 	})
 	defer teardown()
 
-	err := HostingApi{}.DeleteAutoResponder("example.com", "info@example.com")
+	ctx := context.Background()
+	err := HostingApi{}.DeleteAutoResponder(ctx, "example.com", "info@example.com")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -4065,7 +4216,8 @@ func TestHostingDeleteAutoResponderServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, HostingApi{}.DeleteAutoResponder("example.com", "info@example.com")
+				ctx := context.Background()
+				return nil, HostingApi{}.DeleteAutoResponder(ctx, "example.com", "info@example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4082,7 +4234,8 @@ func TestHostingDeleteAutoResponderServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, HostingApi{}.DeleteAutoResponder("example.com", "info@example.com")
+				ctx := context.Background()
+				return nil, HostingApi{}.DeleteAutoResponder(ctx, "example.com", "info@example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4099,7 +4252,8 @@ func TestHostingDeleteAutoResponderServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, HostingApi{}.DeleteAutoResponder("example.com", "info@example.com")
+				ctx := context.Background()
+				return nil, HostingApi{}.DeleteAutoResponder(ctx, "example.com", "info@example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4116,7 +4270,8 @@ func TestHostingDeleteAutoResponderServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, HostingApi{}.DeleteAutoResponder("example.com", "info@example.com")
+				ctx := context.Background()
+				return nil, HostingApi{}.DeleteAutoResponder(ctx, "example.com", "info@example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4182,7 +4337,8 @@ func TestHostingListForwards(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := HostingApi{}.ListForwards("example.com", "random@example.com")
+	ctx := context.Background()
+	response, err := HostingApi{}.ListForwards(ctx, "example.com", "random@example.com")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -4251,7 +4407,8 @@ func TestHostingListForwardsPaginateAndFilter(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := HostingApi{}.ListForwards("example.com", "random@example.com", 1)
+	ctx := context.Background()
+	response, err := HostingApi{}.ListForwards(ctx, "example.com", "random@example.com", 1)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -4283,7 +4440,8 @@ func TestHostingListForwardsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.ListForwards("example.com", "random@example.com")
+				ctx := context.Background()
+				return HostingApi{}.ListForwards(ctx, "example.com", "random@example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4300,7 +4458,8 @@ func TestHostingListForwardsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.ListForwards("example.com", "random@example.com")
+				ctx := context.Background()
+				return HostingApi{}.ListForwards(ctx, "example.com", "random@example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4317,7 +4476,8 @@ func TestHostingListForwardsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId": "289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.ListForwards("example.com", "random@example.com")
+				ctx := context.Background()
+				return HostingApi{}.ListForwards(ctx, "example.com", "random@example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4351,7 +4511,8 @@ func TestHostingCreateForward(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := HostingApi{}.CreateForward("example.com", "random@example.com", map[string]interface{}{
+	ctx := context.Background()
+	resp, err := HostingApi{}.CreateForward(ctx, "example.com", "random@example.com", map[string]interface{}{
 		"active":             true,
 		"destination":        "destination@example.com",
 		"source":             "source@example.com",
@@ -4381,7 +4542,8 @@ func TestHostingCreateForwardServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.CreateForward("example.com", "random@example.com", map[string]interface{}{
+				ctx := context.Background()
+				return HostingApi{}.CreateForward(ctx, "example.com", "random@example.com", map[string]interface{}{
 					"active":             true,
 					"destination":        "destination@example.com",
 					"source":             "source@example.com",
@@ -4404,7 +4566,8 @@ func TestHostingCreateForwardServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.CreateForward("example.com", "random@example.com", map[string]interface{}{
+				ctx := context.Background()
+				return HostingApi{}.CreateForward(ctx, "example.com", "random@example.com", map[string]interface{}{
 					"active":             true,
 					"destination":        "destination@example.com",
 					"source":             "source@example.com",
@@ -4427,7 +4590,8 @@ func TestHostingCreateForwardServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.CreateForward("example.com", "random@example.com", map[string]interface{}{
+				ctx := context.Background()
+				return HostingApi{}.CreateForward(ctx, "example.com", "random@example.com", map[string]interface{}{
 					"active":             true,
 					"destination":        "destination@example.com",
 					"source":             "source@example.com",
@@ -4450,7 +4614,8 @@ func TestHostingCreateForwardServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.CreateForward("example.com", "random@example.com", map[string]interface{}{
+				ctx := context.Background()
+				return HostingApi{}.CreateForward(ctx, "example.com", "random@example.com", map[string]interface{}{
 					"active":             true,
 					"destination":        "destination@example.com",
 					"source":             "source@example.com",
@@ -4490,7 +4655,8 @@ func TestHostingGetForward(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := HostingApi{}.GetForward("example.com", "random@example.com", "destination@example.com")
+	ctx := context.Background()
+	resp, err := HostingApi{}.GetForward(ctx, "example.com", "random@example.com", "destination@example.com")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -4514,7 +4680,8 @@ func TestHostingGetForwardServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetForward("example.com", "random@example.com", "destination@example.com")
+				ctx := context.Background()
+				return HostingApi{}.GetForward(ctx, "example.com", "random@example.com", "destination@example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4531,7 +4698,8 @@ func TestHostingGetForwardServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetForward("example.com", "random@example.com", "destination@example.com")
+				ctx := context.Background()
+				return HostingApi{}.GetForward(ctx, "example.com", "random@example.com", "destination@example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4548,7 +4716,8 @@ func TestHostingGetForwardServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetForward("example.com", "random@example.com", "destination@example.com")
+				ctx := context.Background()
+				return HostingApi{}.GetForward(ctx, "example.com", "random@example.com", "destination@example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4565,7 +4734,8 @@ func TestHostingGetForwardServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.GetForward("example.com", "random@example.com", "destination@example.com")
+				ctx := context.Background()
+				return HostingApi{}.GetForward(ctx, "example.com", "random@example.com", "destination@example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4599,7 +4769,8 @@ func TestHostingUpdateForward(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := HostingApi{}.UpdateForward("example.com", "random@example.com", "destination@example.com", map[string]bool{
+	ctx := context.Background()
+	resp, err := HostingApi{}.UpdateForward(ctx, "example.com", "random@example.com", "destination@example.com", map[string]bool{
 		"active":             true,
 		"spamChecksEnabled":  true,
 		"virusChecksEnabled": true,
@@ -4627,7 +4798,8 @@ func TestHostingUpdateForwardServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateForward("example.com", "random@example.com", "destination@example.com", map[string]bool{
+				ctx := context.Background()
+				return HostingApi{}.UpdateForward(ctx, "example.com", "random@example.com", "destination@example.com", map[string]bool{
 					"active":             true,
 					"spamChecksEnabled":  true,
 					"virusChecksEnabled": true,
@@ -4648,7 +4820,8 @@ func TestHostingUpdateForwardServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateForward("example.com", "random@example.com", "destination@example.com", map[string]bool{
+				ctx := context.Background()
+				return HostingApi{}.UpdateForward(ctx, "example.com", "random@example.com", "destination@example.com", map[string]bool{
 					"active":             true,
 					"spamChecksEnabled":  true,
 					"virusChecksEnabled": true,
@@ -4669,7 +4842,8 @@ func TestHostingUpdateForwardServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateForward("example.com", "random@example.com", "destination@example.com", map[string]bool{
+				ctx := context.Background()
+				return HostingApi{}.UpdateForward(ctx, "example.com", "random@example.com", "destination@example.com", map[string]bool{
 					"active":             true,
 					"spamChecksEnabled":  true,
 					"virusChecksEnabled": true,
@@ -4690,7 +4864,8 @@ func TestHostingUpdateForwardServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return HostingApi{}.UpdateForward("example.com", "random@example.com", "destination@example.com", map[string]bool{
+				ctx := context.Background()
+				return HostingApi{}.UpdateForward(ctx, "example.com", "random@example.com", "destination@example.com", map[string]bool{
 					"active":             true,
 					"spamChecksEnabled":  true,
 					"virusChecksEnabled": true,
@@ -4714,7 +4889,8 @@ func TestHostingDeleteForward(t *testing.T) {
 	})
 	defer teardown()
 
-	err := HostingApi{}.DeleteForward("example.com", "email", "dest")
+	ctx := context.Background()
+	err := HostingApi{}.DeleteForward(ctx, "example.com", "email", "dest")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -4731,7 +4907,8 @@ func TestHostingDeleteForwardServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, HostingApi{}.DeleteForward("example.com", "email", "dest")
+				ctx := context.Background()
+				return nil, HostingApi{}.DeleteForward(ctx, "example.com", "email", "dest")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4748,7 +4925,8 @@ func TestHostingDeleteForwardServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, HostingApi{}.DeleteForward("example.com", "email", "dest")
+				ctx := context.Background()
+				return nil, HostingApi{}.DeleteForward(ctx, "example.com", "email", "dest")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4765,7 +4943,8 @@ func TestHostingDeleteForwardServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, HostingApi{}.DeleteForward("example.com", "email", "dest")
+				ctx := context.Background()
+				return nil, HostingApi{}.DeleteForward(ctx, "example.com", "email", "dest")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -4782,7 +4961,8 @@ func TestHostingDeleteForwardServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, HostingApi{}.DeleteForward("example.com", "email", "dest")
+				ctx := context.Background()
+				return nil, HostingApi{}.DeleteForward(ctx, "example.com", "email", "dest")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",

--- a/invoice.go
+++ b/invoice.go
@@ -1,6 +1,7 @@
 package leaseweb
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -73,7 +74,7 @@ func (ia InvoiceApi) getPath(endpoint string) string {
 	return "/invoices/" + INVOICE_API_VERSION + endpoint
 }
 
-func (ia InvoiceApi) List(args ...int) (*Invoices, error) {
+func (ia InvoiceApi) List(ctx context.Context, args ...int) (*Invoices, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -84,13 +85,13 @@ func (ia InvoiceApi) List(args ...int) (*Invoices, error) {
 
 	path := ia.getPath("/invoices?" + v.Encode())
 	result := &Invoices{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ia InvoiceApi) ListProForma(args ...int) (*InvoiceProForma, error) {
+func (ia InvoiceApi) ListProForma(ctx context.Context, args ...int) (*InvoiceProForma, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -101,16 +102,16 @@ func (ia InvoiceApi) ListProForma(args ...int) (*InvoiceProForma, error) {
 
 	path := ia.getPath("/invoices/proforma?" + v.Encode())
 	result := &InvoiceProForma{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ia InvoiceApi) Get(invoiceId string) (*Invoice, error) {
+func (ia InvoiceApi) Get(ctx context.Context, invoiceId string) (*Invoice, error) {
 	path := ia.getPath("/invoices/" + invoiceId)
 	result := &Invoice{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/invoice_test.go
+++ b/invoice_test.go
@@ -1,6 +1,7 @@
 package leaseweb
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -40,7 +41,8 @@ func TestInvoiceList(t *testing.T) {
 	defer teardown()
 
 	invoiceApi := InvoiceApi{}
-	response, err := invoiceApi.List()
+	ctx := context.Background()
+	response, err := invoiceApi.List(ctx)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -80,7 +82,8 @@ func TestInvoiceListBeEmpty(t *testing.T) {
 	defer teardown()
 
 	invoiceApi := InvoiceApi{}
-	response, err := invoiceApi.List()
+	ctx := context.Background()
+	response, err := invoiceApi.List(ctx)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -99,7 +102,8 @@ func TestInvoiceListPaginate(t *testing.T) {
 	defer teardown()
 
 	invoiceApi := InvoiceApi{}
-	response, err := invoiceApi.List(1)
+	ctx := context.Background()
+	response, err := invoiceApi.List(ctx, 1)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -120,7 +124,8 @@ func TestInvoiceListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return InvoiceApi{}.List()
+				ctx := context.Background()
+				return InvoiceApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -137,7 +142,8 @@ func TestInvoiceListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return InvoiceApi{}.List()
+				ctx := context.Background()
+				return InvoiceApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -154,7 +160,8 @@ func TestInvoiceListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return InvoiceApi{}.List()
+				ctx := context.Background()
+				return InvoiceApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -171,7 +178,8 @@ func TestInvoiceListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return InvoiceApi{}.List()
+				ctx := context.Background()
+				return InvoiceApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -223,7 +231,8 @@ func TestInvoiceListProForma(t *testing.T) {
 	defer teardown()
 
 	invoiceApi := InvoiceApi{}
-	response, err := invoiceApi.ListProForma()
+	ctx := context.Background()
+	response, err := invoiceApi.ListProForma(ctx)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -290,7 +299,8 @@ func TestInvoiceListProFormaPaginate(t *testing.T) {
 	defer teardown()
 
 	invoiceApi := InvoiceApi{}
-	response, err := invoiceApi.ListProForma(1)
+	ctx := context.Background()
+	response, err := invoiceApi.ListProForma(ctx, 1)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -328,7 +338,8 @@ func TestInvoiceListProFormaServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return InvoiceApi{}.ListProForma()
+				ctx := context.Background()
+				return InvoiceApi{}.ListProForma(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -345,7 +356,8 @@ func TestInvoiceListProFormaServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return InvoiceApi{}.ListProForma()
+				ctx := context.Background()
+				return InvoiceApi{}.ListProForma(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -362,7 +374,8 @@ func TestInvoiceListProFormaServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return InvoiceApi{}.ListProForma()
+				ctx := context.Background()
+				return InvoiceApi{}.ListProForma(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -379,7 +392,8 @@ func TestInvoiceListProFormaServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return InvoiceApi{}.ListProForma()
+				ctx := context.Background()
+				return InvoiceApi{}.ListProForma(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -429,7 +443,8 @@ func TestInvoiceGet(t *testing.T) {
 	defer teardown()
 
 	invoiceApi := InvoiceApi{}
-	response, err := invoiceApi.Get("00000001")
+	ctx := context.Background()
+	response, err := invoiceApi.Get(ctx, "00000001")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -472,7 +487,8 @@ func TestInvoiceGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return InvoiceApi{}.Get("000000001")
+				ctx := context.Background()
+				return InvoiceApi{}.Get(ctx, "000000001")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -489,7 +505,8 @@ func TestInvoiceGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "Access to the requested resource is forbidden."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return InvoiceApi{}.Get("000000001")
+				ctx := context.Background()
+				return InvoiceApi{}.Get(ctx, "000000001")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -506,7 +523,8 @@ func TestInvoiceGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The API could not handle your request at this time."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return InvoiceApi{}.Get("000000001")
+				ctx := context.Background()
+				return InvoiceApi{}.Get(ctx, "000000001")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -523,7 +541,8 @@ func TestInvoiceGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The API is not available at the moment."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return InvoiceApi{}.Get("000000001")
+				ctx := context.Background()
+				return InvoiceApi{}.Get(ctx, "000000001")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",

--- a/ip_management.go
+++ b/ip_management.go
@@ -1,6 +1,7 @@
 package leaseweb
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -14,7 +15,7 @@ func (ima IpManagementApi) getPath(endpoint string) string {
 	return "/ipMgmt/" + IP_MANAGEMENT_API_VERSION + endpoint
 }
 
-func (ima IpManagementApi) List(params ...map[string]interface{}) (*Ips, error) {
+func (ima IpManagementApi) List(ctx context.Context, params ...map[string]interface{}) (*Ips, error) {
 	v := url.Values{}
 	if len(params) != 0 {
 		for key, value := range params[0] {
@@ -23,32 +24,32 @@ func (ima IpManagementApi) List(params ...map[string]interface{}) (*Ips, error) 
 	}
 	path := ima.getPath("/ips?" + v.Encode())
 	result := &Ips{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ima IpManagementApi) Get(ip string) (*Ip, error) {
+func (ima IpManagementApi) Get(ctx context.Context, ip string) (*Ip, error) {
 	path := ima.getPath("/ips/" + ip)
 	result := &Ip{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ima IpManagementApi) Update(ip, reverseLookup string) (*Ip, error) {
+func (ima IpManagementApi) Update(ctx context.Context, ip, reverseLookup string) (*Ip, error) {
 	payload := map[string]string{"reverseLookup": reverseLookup}
 	path := ima.getPath("/ips/" + ip)
 	result := &Ip{}
-	if err := doRequest(http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ima IpManagementApi) NullRouteAnIp(ip string, params ...map[string]string) (*NullRoute, error) {
+func (ima IpManagementApi) NullRouteAnIp(ctx context.Context, ip string, params ...map[string]string) (*NullRoute, error) {
 	payload := make(map[string]string)
 	if len(params) != 0 {
 		for key, value := range params[0] {
@@ -57,18 +58,18 @@ func (ima IpManagementApi) NullRouteAnIp(ip string, params ...map[string]string)
 	}
 	path := ima.getPath("/ips/" + ip + "/nullRoute")
 	result := &NullRoute{}
-	if err := doRequest(http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ima IpManagementApi) RemoveNullRouteAnIp(ip string) error {
+func (ima IpManagementApi) RemoveNullRouteAnIp(ctx context.Context, ip string) error {
 	path := ima.getPath("/ips/" + ip + "/nullRoute")
-	return doRequest(http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path)
 }
 
-func (ima IpManagementApi) ListNullRoutes(params ...map[string]interface{}) (*NullRoutes, error) {
+func (ima IpManagementApi) ListNullRoutes(ctx context.Context, params ...map[string]interface{}) (*NullRoutes, error) {
 	v := url.Values{}
 	if len(params) != 0 {
 		for key, value := range params[0] {
@@ -77,22 +78,22 @@ func (ima IpManagementApi) ListNullRoutes(params ...map[string]interface{}) (*Nu
 	}
 	path := ima.getPath("/nullRoutes?" + v.Encode())
 	result := &NullRoutes{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ima IpManagementApi) GetNullRoute(id string) (*NullRoute, error) {
+func (ima IpManagementApi) GetNullRoute(ctx context.Context, id string) (*NullRoute, error) {
 	path := ima.getPath("/nullRoutes/" + id)
 	result := &NullRoute{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (ima IpManagementApi) UpdateNullRoute(id string, params ...map[string]string) (*NullRoute, error) {
+func (ima IpManagementApi) UpdateNullRoute(ctx context.Context, id string, params ...map[string]string) (*NullRoute, error) {
 	payload := make(map[string]string)
 	if len(params) != 0 {
 		for key, value := range params[0] {
@@ -101,7 +102,7 @@ func (ima IpManagementApi) UpdateNullRoute(id string, params ...map[string]strin
 	}
 	path := ima.getPath("/nullRoutes/" + id)
 	result := &NullRoute{}
-	if err := doRequest(http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/ip_management_test.go
+++ b/ip_management_test.go
@@ -1,6 +1,7 @@
 package leaseweb
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -64,7 +65,8 @@ func TestIpManagementListIps(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := IpManagementApi{}.List()
+	ctx := context.Background()
+	response, err := IpManagementApi{}.List(ctx)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -142,7 +144,8 @@ func TestIpManagementListIpsPaginate(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := IpManagementApi{}.List(map[string]interface{}{"offset": 1})
+	ctx := context.Background()
+	response, err := IpManagementApi{}.List(ctx, map[string]interface{}{"offset": 1})
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -179,7 +182,8 @@ func TestIpManagementListIpsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return IpManagementApi{}.List(map[string]interface{}{"offset": 1})
+				ctx := context.Background()
+				return IpManagementApi{}.List(ctx, map[string]interface{}{"offset": 1})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -196,7 +200,8 @@ func TestIpManagementListIpsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return IpManagementApi{}.List(map[string]interface{}{"offset": 1})
+				ctx := context.Background()
+				return IpManagementApi{}.List(ctx, map[string]interface{}{"offset": 1})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -213,7 +218,8 @@ func TestIpManagementListIpsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return IpManagementApi{}.List(map[string]interface{}{"offset": 1})
+				ctx := context.Background()
+				return IpManagementApi{}.List(ctx, map[string]interface{}{"offset": 1})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -230,7 +236,8 @@ func TestIpManagementListIpsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return IpManagementApi{}.List(map[string]interface{}{"offset": 1})
+				ctx := context.Background()
+				return IpManagementApi{}.List(ctx, map[string]interface{}{"offset": 1})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -269,7 +276,8 @@ func TestIpManagementGetIps(t *testing.T) {
 	})
 	defer teardown()
 
-	Ip, err := IpManagementApi{}.Get("192.0.2.1")
+	ctx := context.Background()
+	Ip, err := IpManagementApi{}.Get(ctx, "192.0.2.1")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -300,7 +308,8 @@ func TestIpManagementGetIpsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return IpManagementApi{}.Get("192.0.2.1")
+				ctx := context.Background()
+				return IpManagementApi{}.Get(ctx, "192.0.2.1")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -317,7 +326,8 @@ func TestIpManagementGetIpsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return IpManagementApi{}.Get("192.0.2.1")
+				ctx := context.Background()
+				return IpManagementApi{}.Get(ctx, "192.0.2.1")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -334,7 +344,8 @@ func TestIpManagementGetIpsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return IpManagementApi{}.Get("192.0.2.1")
+				ctx := context.Background()
+				return IpManagementApi{}.Get(ctx, "192.0.2.1")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -351,7 +362,8 @@ func TestIpManagementGetIpsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return IpManagementApi{}.Get("192.0.2.1")
+				ctx := context.Background()
+				return IpManagementApi{}.Get(ctx, "192.0.2.1")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -390,7 +402,8 @@ func TestIpManagementUpdate(t *testing.T) {
 	})
 	defer teardown()
 
-	Ip, err := IpManagementApi{}.Update("192.0.2.1", "mydomain1.example.com")
+	ctx := context.Background()
+	Ip, err := IpManagementApi{}.Update(ctx, "192.0.2.1", "mydomain1.example.com")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -421,7 +434,8 @@ func TestIpManagementUpdateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return IpManagementApi{}.Update("192.0.2.1", "mydomain1.example.com")
+				ctx := context.Background()
+				return IpManagementApi{}.Update(ctx, "192.0.2.1", "mydomain1.example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -438,7 +452,8 @@ func TestIpManagementUpdateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return IpManagementApi{}.Update("192.0.2.1", "mydomain1.example.com")
+				ctx := context.Background()
+				return IpManagementApi{}.Update(ctx, "192.0.2.1", "mydomain1.example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -455,7 +470,8 @@ func TestIpManagementUpdateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return IpManagementApi{}.Update("192.0.2.1", "mydomain1.example.com")
+				ctx := context.Background()
+				return IpManagementApi{}.Update(ctx, "192.0.2.1", "mydomain1.example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -472,7 +488,8 @@ func TestIpManagementUpdateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return IpManagementApi{}.Update("192.0.2.1", "mydomain1.example.com")
+				ctx := context.Background()
+				return IpManagementApi{}.Update(ctx, "192.0.2.1", "mydomain1.example.com")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -512,7 +529,8 @@ func TestIpManagementNullRouteAnIp(t *testing.T) {
 		"ticketId":             "188612",
 		"comment":              "This IP is evil",
 	}
-	NullRoute, err := IpManagementApi{}.NullRouteAnIp("192.0.2.1", payload)
+	ctx := context.Background()
+	NullRoute, err := IpManagementApi{}.NullRouteAnIp(ctx, "192.0.2.1", payload)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -546,7 +564,8 @@ func TestIpManagementNullRouteAnIpServerErrors(t *testing.T) {
 					"ticketId":             "188612",
 					"comment":              "This IP is evil",
 				}
-				return IpManagementApi{}.NullRouteAnIp("192.0.2.1", payload)
+				ctx := context.Background()
+				return IpManagementApi{}.NullRouteAnIp(ctx, "192.0.2.1", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -568,7 +587,8 @@ func TestIpManagementNullRouteAnIpServerErrors(t *testing.T) {
 					"ticketId":             "188612",
 					"comment":              "This IP is evil",
 				}
-				return IpManagementApi{}.NullRouteAnIp("192.0.2.1", payload)
+				ctx := context.Background()
+				return IpManagementApi{}.NullRouteAnIp(ctx, "192.0.2.1", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -590,7 +610,8 @@ func TestIpManagementNullRouteAnIpServerErrors(t *testing.T) {
 					"ticketId":             "188612",
 					"comment":              "This IP is evil",
 				}
-				return IpManagementApi{}.NullRouteAnIp("192.0.2.1", payload)
+				ctx := context.Background()
+				return IpManagementApi{}.NullRouteAnIp(ctx, "192.0.2.1", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -612,7 +633,8 @@ func TestIpManagementNullRouteAnIpServerErrors(t *testing.T) {
 					"ticketId":             "188612",
 					"comment":              "This IP is evil",
 				}
-				return IpManagementApi{}.NullRouteAnIp("192.0.2.1", payload)
+				ctx := context.Background()
+				return IpManagementApi{}.NullRouteAnIp(ctx, "192.0.2.1", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -632,7 +654,8 @@ func TestIpManagementRemoveNullRouteAnIp(t *testing.T) {
 	})
 	defer teardown()
 
-	err := IpManagementApi{}.RemoveNullRouteAnIp("192.0.2.1")
+	ctx := context.Background()
+	err := IpManagementApi{}.RemoveNullRouteAnIp(ctx, "192.0.2.1")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -649,7 +672,8 @@ func TestIpManagementRemoveNullRouteAnIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, IpManagementApi{}.RemoveNullRouteAnIp("192.0.2.1")
+				ctx := context.Background()
+				return nil, IpManagementApi{}.RemoveNullRouteAnIp(ctx, "192.0.2.1")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -666,7 +690,8 @@ func TestIpManagementRemoveNullRouteAnIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, IpManagementApi{}.RemoveNullRouteAnIp("192.0.2.1")
+				ctx := context.Background()
+				return nil, IpManagementApi{}.RemoveNullRouteAnIp(ctx, "192.0.2.1")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -683,7 +708,8 @@ func TestIpManagementRemoveNullRouteAnIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, IpManagementApi{}.RemoveNullRouteAnIp("192.0.2.1")
+				ctx := context.Background()
+				return nil, IpManagementApi{}.RemoveNullRouteAnIp(ctx, "192.0.2.1")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -700,7 +726,8 @@ func TestIpManagementRemoveNullRouteAnIpServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, IpManagementApi{}.RemoveNullRouteAnIp("192.0.2.1")
+				ctx := context.Background()
+				return nil, IpManagementApi{}.RemoveNullRouteAnIp(ctx, "192.0.2.1")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -760,7 +787,8 @@ func TestIpManagementListNullRoutes(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := IpManagementApi{}.ListNullRoutes()
+	ctx := context.Background()
+	response, err := IpManagementApi{}.ListNullRoutes(ctx)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -830,7 +858,8 @@ func TestIpManagementListNullRoutesPaginate(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := IpManagementApi{}.ListNullRoutes(map[string]interface{}{"offset": 1})
+	ctx := context.Background()
+	response, err := IpManagementApi{}.ListNullRoutes(ctx, map[string]interface{}{"offset": 1})
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -865,7 +894,8 @@ func TestIpManagementListNullRoutesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return IpManagementApi{}.ListNullRoutes(map[string]interface{}{"offset": 1})
+				ctx := context.Background()
+				return IpManagementApi{}.ListNullRoutes(ctx, map[string]interface{}{"offset": 1})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -882,7 +912,8 @@ func TestIpManagementListNullRoutesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return IpManagementApi{}.ListNullRoutes(map[string]interface{}{"offset": 1})
+				ctx := context.Background()
+				return IpManagementApi{}.ListNullRoutes(ctx, map[string]interface{}{"offset": 1})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -899,7 +930,8 @@ func TestIpManagementListNullRoutesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return IpManagementApi{}.ListNullRoutes(map[string]interface{}{"offset": 1})
+				ctx := context.Background()
+				return IpManagementApi{}.ListNullRoutes(ctx, map[string]interface{}{"offset": 1})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -916,7 +948,8 @@ func TestIpManagementListNullRoutesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return IpManagementApi{}.ListNullRoutes(map[string]interface{}{"offset": 1})
+				ctx := context.Background()
+				return IpManagementApi{}.ListNullRoutes(ctx, map[string]interface{}{"offset": 1})
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -951,7 +984,8 @@ func TestIpManagementGetNullRoute(t *testing.T) {
 	})
 	defer teardown()
 
-	NullRoute, err := IpManagementApi{}.GetNullRoute("123456")
+	ctx := context.Background()
+	NullRoute, err := IpManagementApi{}.GetNullRoute(ctx, "123456")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -981,7 +1015,8 @@ func TestIpManagementGetNullRouteServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return IpManagementApi{}.GetNullRoute("123456")
+				ctx := context.Background()
+				return IpManagementApi{}.GetNullRoute(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -998,7 +1033,8 @@ func TestIpManagementGetNullRouteServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return IpManagementApi{}.GetNullRoute("123456")
+				ctx := context.Background()
+				return IpManagementApi{}.GetNullRoute(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1015,7 +1051,8 @@ func TestIpManagementGetNullRouteServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return IpManagementApi{}.GetNullRoute("123456")
+				ctx := context.Background()
+				return IpManagementApi{}.GetNullRoute(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1032,7 +1069,8 @@ func TestIpManagementGetNullRouteServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return IpManagementApi{}.GetNullRoute("123456")
+				ctx := context.Background()
+				return IpManagementApi{}.GetNullRoute(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1072,7 +1110,8 @@ func TestIpManagementUpdateNullRouteHistory(t *testing.T) {
 		"ticketId":             "188612",
 		"comment":              "This IP is evil",
 	}
-	NullRoute, err := IpManagementApi{}.UpdateNullRoute("123456", payload)
+	ctx := context.Background()
+	NullRoute, err := IpManagementApi{}.UpdateNullRoute(ctx, "123456", payload)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -1107,7 +1146,8 @@ func TestIpManagementUpdateNullRouteHistoryServerErrors(t *testing.T) {
 					"ticketId":             "188612",
 					"comment":              "This IP is evil",
 				}
-				return IpManagementApi{}.UpdateNullRoute("123456", payload)
+				ctx := context.Background()
+				return IpManagementApi{}.UpdateNullRoute(ctx, "123456", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1129,7 +1169,8 @@ func TestIpManagementUpdateNullRouteHistoryServerErrors(t *testing.T) {
 					"ticketId":             "188612",
 					"comment":              "This IP is evil",
 				}
-				return IpManagementApi{}.UpdateNullRoute("123456", payload)
+				ctx := context.Background()
+				return IpManagementApi{}.UpdateNullRoute(ctx, "123456", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1151,7 +1192,8 @@ func TestIpManagementUpdateNullRouteHistoryServerErrors(t *testing.T) {
 					"ticketId":             "188612",
 					"comment":              "This IP is evil",
 				}
-				return IpManagementApi{}.UpdateNullRoute("123456", payload)
+				ctx := context.Background()
+				return IpManagementApi{}.UpdateNullRoute(ctx, "123456", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1173,7 +1215,8 @@ func TestIpManagementUpdateNullRouteHistoryServerErrors(t *testing.T) {
 					"ticketId":             "188612",
 					"comment":              "This IP is evil",
 				}
-				return IpManagementApi{}.UpdateNullRoute("123456", payload)
+				ctx := context.Background()
+				return IpManagementApi{}.UpdateNullRoute(ctx, "123456", payload)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",

--- a/private_cloud.go
+++ b/private_cloud.go
@@ -1,6 +1,7 @@
 package leaseweb
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -58,7 +59,7 @@ func (pca PrivateCloudApi) getPath(endpoint string) string {
 	return "/cloud/" + PRIVATE_CLOUD_API_VERSION + endpoint
 }
 
-func (pca PrivateCloudApi) List(args ...interface{}) (*PrivateClouds, error) {
+func (pca PrivateCloudApi) List(ctx context.Context, args ...interface{}) (*PrivateClouds, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -69,22 +70,22 @@ func (pca PrivateCloudApi) List(args ...interface{}) (*PrivateClouds, error) {
 
 	path := pca.getPath("/privateClouds?" + v.Encode())
 	result := &PrivateClouds{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (pca PrivateCloudApi) Get(privateCloudId string) (*PrivateCloud, error) {
+func (pca PrivateCloudApi) Get(ctx context.Context, privateCloudId string) (*PrivateCloud, error) {
 	path := pca.getPath("/privateClouds/" + privateCloudId)
 	result := &PrivateCloud{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (pca PrivateCloudApi) ListCredentials(privateCloudId string, credentialType string, args ...int) (*Credentials, error) {
+func (pca PrivateCloudApi) ListCredentials(ctx context.Context, privateCloudId string, credentialType string, args ...int) (*Credentials, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -95,22 +96,22 @@ func (pca PrivateCloudApi) ListCredentials(privateCloudId string, credentialType
 
 	path := pca.getPath("/privateClouds/" + privateCloudId + "/credentials/" + credentialType + v.Encode())
 	result := &Credentials{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (pca PrivateCloudApi) GetCredential(privateCloudId string, credentialType string, username string) (*Credential, error) {
+func (pca PrivateCloudApi) GetCredential(ctx context.Context, privateCloudId string, credentialType string, username string) (*Credential, error) {
 	path := pca.getPath("/privateClouds/" + privateCloudId + "/credentials/" + credentialType + "/" + username)
 	result := &Credential{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (pca PrivateCloudApi) GetDataTrafficMetrics(privateCloudId string, args ...interface{}) (*DataTrafficMetricsV2, error) {
+func (pca PrivateCloudApi) GetDataTrafficMetrics(ctx context.Context, privateCloudId string, args ...interface{}) (*DataTrafficMetricsV2, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("granularity", fmt.Sprint(args[0]))
@@ -127,13 +128,13 @@ func (pca PrivateCloudApi) GetDataTrafficMetrics(privateCloudId string, args ...
 
 	path := pca.getPath("/privateClouds/" + privateCloudId + "/metrics/datatraffic?" + v.Encode())
 	result := &DataTrafficMetricsV2{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (pca PrivateCloudApi) GetBandWidthMetrics(privateCloudId string, args ...interface{}) (*BandWidthMetrics, error) {
+func (pca PrivateCloudApi) GetBandWidthMetrics(ctx context.Context, privateCloudId string, args ...interface{}) (*BandWidthMetrics, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("granularity", fmt.Sprint(args[0]))
@@ -150,13 +151,13 @@ func (pca PrivateCloudApi) GetBandWidthMetrics(privateCloudId string, args ...in
 
 	path := pca.getPath("/privateClouds/" + privateCloudId + "/metrics/bandwidth?" + v.Encode())
 	result := &BandWidthMetrics{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (pca PrivateCloudApi) GetCpuMetrics(privateCloudId string, args ...interface{}) (*PrivateCloudCpuMetrics, error) {
+func (pca PrivateCloudApi) GetCpuMetrics(ctx context.Context, privateCloudId string, args ...interface{}) (*PrivateCloudCpuMetrics, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("granularity", fmt.Sprint(args[0]))
@@ -172,13 +173,13 @@ func (pca PrivateCloudApi) GetCpuMetrics(privateCloudId string, args ...interfac
 	}
 	path := pca.getPath("/privateClouds/" + privateCloudId + "/metrics/cpu?" + v.Encode())
 	result := &PrivateCloudCpuMetrics{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (pca PrivateCloudApi) GetMemoryMetrics(privateCloudId string, args ...interface{}) (*PrivateCloudMemoryMetrics, error) {
+func (pca PrivateCloudApi) GetMemoryMetrics(ctx context.Context, privateCloudId string, args ...interface{}) (*PrivateCloudMemoryMetrics, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("granularity", fmt.Sprint(args[0]))
@@ -194,13 +195,13 @@ func (pca PrivateCloudApi) GetMemoryMetrics(privateCloudId string, args ...inter
 	}
 	path := pca.getPath("/privateClouds/" + privateCloudId + "/metrics/memory?" + v.Encode())
 	result := &PrivateCloudMemoryMetrics{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (pca PrivateCloudApi) GetStorageMetrics(privateCloudId string, args ...interface{}) (*PrivateCloudStorageMetrics, error) {
+func (pca PrivateCloudApi) GetStorageMetrics(ctx context.Context, privateCloudId string, args ...interface{}) (*PrivateCloudStorageMetrics, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("granularity", fmt.Sprint(args[0]))
@@ -216,7 +217,7 @@ func (pca PrivateCloudApi) GetStorageMetrics(privateCloudId string, args ...inte
 	}
 	path := pca.getPath("/privateClouds/" + privateCloudId + "/metrics/storage?" + v.Encode())
 	result := &PrivateCloudStorageMetrics{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/private_cloud_test.go
+++ b/private_cloud_test.go
@@ -1,6 +1,7 @@
 package leaseweb
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -60,7 +61,8 @@ func TestPrivateCloudList(t *testing.T) {
 	defer teardown()
 
 	privateCloudApi := PrivateCloudApi{}
-	response, err := privateCloudApi.List()
+	ctx := context.Background()
+	response, err := privateCloudApi.List(ctx)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -106,7 +108,8 @@ func TestPrivateCloudListBeEmpty(t *testing.T) {
 	defer teardown()
 
 	privateCloudApi := PrivateCloudApi{}
-	response, err := privateCloudApi.List()
+	ctx := context.Background()
+	response, err := privateCloudApi.List(ctx)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -125,7 +128,8 @@ func TestPrivateCloudListPaginate(t *testing.T) {
 	defer teardown()
 
 	privateCloudApi := PrivateCloudApi{}
-	response, err := privateCloudApi.List(10, 20)
+	ctx := context.Background()
+	response, err := privateCloudApi.List(ctx, 10, 20)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -146,7 +150,8 @@ func TestPrivateCloudListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.List()
+				ctx := context.Background()
+				return PrivateCloudApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "ACCESS_DENIED",
@@ -162,7 +167,8 @@ func TestPrivateCloudListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.List()
+				ctx := context.Background()
+				return PrivateCloudApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "SERVER_ERROR",
@@ -178,7 +184,8 @@ func TestPrivateCloudListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.List()
+				ctx := context.Background()
+				return PrivateCloudApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "TEMPORARILY_UNAVAILABLE",
@@ -239,7 +246,8 @@ func TestPrivateCloudGet(t *testing.T) {
 	defer teardown()
 
 	privateCloudApi := PrivateCloudApi{}
-	response, err := privateCloudApi.Get("218030")
+	ctx := context.Background()
+	response, err := privateCloudApi.Get(ctx, "218030")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -281,7 +289,8 @@ func TestPrivateCloudGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.Get("218030")
+				ctx := context.Background()
+				return PrivateCloudApi{}.Get(ctx, "218030")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "ACCESS_DENIED",
@@ -297,7 +306,8 @@ func TestPrivateCloudGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "404", "errorMessage": "Resource 218030 was not found", "userMessage": "Resource with id 218030 not found."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.Get("218030")
+				ctx := context.Background()
+				return PrivateCloudApi{}.Get(ctx, "218030")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "404",
@@ -314,7 +324,8 @@ func TestPrivateCloudGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.Get("218030")
+				ctx := context.Background()
+				return PrivateCloudApi{}.Get(ctx, "218030")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "SERVER_ERROR",
@@ -330,7 +341,8 @@ func TestPrivateCloudGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.Get("218030")
+				ctx := context.Background()
+				return PrivateCloudApi{}.Get(ctx, "218030")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "TEMPORARILY_UNAVAILABLE",
@@ -356,7 +368,8 @@ func TestPrivateCloudListCredentials(t *testing.T) {
 	defer teardown()
 
 	privateCloudApi := PrivateCloudApi{}
-	response, err := privateCloudApi.ListCredentials("12345678", "REMOTE_MANAGEMENT")
+	ctx := context.Background()
+	response, err := privateCloudApi.ListCredentials(ctx, "12345678", "REMOTE_MANAGEMENT")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -380,7 +393,8 @@ func TestPrivateCloudListCredentialsBeEmpty(t *testing.T) {
 	defer teardown()
 
 	privateCloudApi := PrivateCloudApi{}
-	response, err := privateCloudApi.ListCredentials("12345678", "REMOTE_MANAGEMENT")
+	ctx := context.Background()
+	response, err := privateCloudApi.ListCredentials(ctx, "12345678", "REMOTE_MANAGEMENT")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -406,7 +420,8 @@ func TestPrivateCloudListCredentialsPaginate(t *testing.T) {
 	defer teardown()
 
 	privateCloudApi := PrivateCloudApi{}
-	response, err := privateCloudApi.ListCredentials("12345678", "REMOTE_MANAGEMENT", 1, 10)
+	ctx := context.Background()
+	response, err := privateCloudApi.ListCredentials(ctx, "12345678", "REMOTE_MANAGEMENT", 1, 10)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -433,7 +448,8 @@ func TestPrivateCloudListCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.ListCredentials("12345678", "REMOTE_MANAGEMENT")
+				ctx := context.Background()
+				return PrivateCloudApi{}.ListCredentials(ctx, "12345678", "REMOTE_MANAGEMENT")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "ACCESS_DENIED",
@@ -449,7 +465,8 @@ func TestPrivateCloudListCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "404", "errorMessage": "Resource 218030 was not found", "userMessage": "Resource with id 218030 not found."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.ListCredentials("12345678", "REMOTE_MANAGEMENT")
+				ctx := context.Background()
+				return PrivateCloudApi{}.ListCredentials(ctx, "12345678", "REMOTE_MANAGEMENT")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "404",
@@ -466,7 +483,8 @@ func TestPrivateCloudListCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.ListCredentials("12345678", "REMOTE_MANAGEMENT")
+				ctx := context.Background()
+				return PrivateCloudApi{}.ListCredentials(ctx, "12345678", "REMOTE_MANAGEMENT")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "SERVER_ERROR",
@@ -482,7 +500,8 @@ func TestPrivateCloudListCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.ListCredentials("12345678", "REMOTE_MANAGEMENT")
+				ctx := context.Background()
+				return PrivateCloudApi{}.ListCredentials(ctx, "12345678", "REMOTE_MANAGEMENT")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "TEMPORARILY_UNAVAILABLE",
@@ -507,7 +526,8 @@ func TestPrivateCloudGetCredential(t *testing.T) {
 	defer teardown()
 
 	privateCloudApi := PrivateCloudApi{}
-	response, err := privateCloudApi.GetCredential("218030", "REMOTE_MANAGEMENT", "root")
+	ctx := context.Background()
+	response, err := privateCloudApi.GetCredential(ctx, "218030", "REMOTE_MANAGEMENT", "root")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -529,7 +549,8 @@ func TestPrivateCloudGetCredentialServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.GetCredential("218030", "REMOTE_MANAGEMENT", "root")
+				ctx := context.Background()
+				return PrivateCloudApi{}.GetCredential(ctx, "218030", "REMOTE_MANAGEMENT", "root")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "ACCESS_DENIED",
@@ -545,7 +566,8 @@ func TestPrivateCloudGetCredentialServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "404", "errorMessage": "Resource 218030 was not found", "userMessage": "Resource with id 218030 not found."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.GetCredential("218030", "REMOTE_MANAGEMENT", "root")
+				ctx := context.Background()
+				return PrivateCloudApi{}.GetCredential(ctx, "218030", "REMOTE_MANAGEMENT", "root")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "404",
@@ -562,7 +584,8 @@ func TestPrivateCloudGetCredentialServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.GetCredential("218030", "REMOTE_MANAGEMENT", "root")
+				ctx := context.Background()
+				return PrivateCloudApi{}.GetCredential(ctx, "218030", "REMOTE_MANAGEMENT", "root")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "SERVER_ERROR",
@@ -578,7 +601,8 @@ func TestPrivateCloudGetCredentialServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.GetCredential("218030", "REMOTE_MANAGEMENT", "root")
+				ctx := context.Background()
+				return PrivateCloudApi{}.GetCredential(ctx, "218030", "REMOTE_MANAGEMENT", "root")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "TEMPORARILY_UNAVAILABLE",
@@ -633,7 +657,8 @@ func TestPrivateCloudGetDataTrafficMetrics(t *testing.T) {
 	defer teardown()
 
 	privateCloudApi := PrivateCloudApi{}
-	response, err := privateCloudApi.GetDataTrafficMetrics("218030")
+	ctx := context.Background()
+	response, err := privateCloudApi.GetDataTrafficMetrics(ctx, "218030")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -698,7 +723,8 @@ func TestPrivateCloudGetDataTrafficMetricsWithFilter(t *testing.T) {
 	defer teardown()
 
 	privateCloudApi := PrivateCloudApi{}
-	response, err := privateCloudApi.GetDataTrafficMetrics("218030", "SUM", "MONTH", "2017-07-01T00:00:00+00:00", "2017-07-02T00:00:00+00:00")
+	ctx := context.Background()
+	response, err := privateCloudApi.GetDataTrafficMetrics(ctx, "218030", "SUM", "MONTH", "2017-07-01T00:00:00+00:00", "2017-07-02T00:00:00+00:00")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -730,7 +756,8 @@ func TestPrivateCloudGetDataTrafficMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.GetDataTrafficMetrics("218030")
+				ctx := context.Background()
+				return PrivateCloudApi{}.GetDataTrafficMetrics(ctx, "218030")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "ACCESS_DENIED",
@@ -746,7 +773,8 @@ func TestPrivateCloudGetDataTrafficMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "404", "errorMessage": "Resource 218030 was not found", "userMessage": "Resource with id 218030 not found."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.GetDataTrafficMetrics("218030")
+				ctx := context.Background()
+				return PrivateCloudApi{}.GetDataTrafficMetrics(ctx, "218030")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "404",
@@ -763,7 +791,8 @@ func TestPrivateCloudGetDataTrafficMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.GetDataTrafficMetrics("218030")
+				ctx := context.Background()
+				return PrivateCloudApi{}.GetDataTrafficMetrics(ctx, "218030")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "SERVER_ERROR",
@@ -779,7 +808,8 @@ func TestPrivateCloudGetDataTrafficMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.GetDataTrafficMetrics("218030")
+				ctx := context.Background()
+				return PrivateCloudApi{}.GetDataTrafficMetrics(ctx, "218030")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "TEMPORARILY_UNAVAILABLE",
@@ -834,7 +864,8 @@ func TestPrivateCloudGetBandWidthMetrics(t *testing.T) {
 	defer teardown()
 
 	privateCloudApi := PrivateCloudApi{}
-	response, err := privateCloudApi.GetBandWidthMetrics("218030")
+	ctx := context.Background()
+	response, err := privateCloudApi.GetBandWidthMetrics(ctx, "218030")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -899,7 +930,8 @@ func TestPrivateCloudGetBandWidthMetricsWithFilter(t *testing.T) {
 	defer teardown()
 
 	privateCloudApi := PrivateCloudApi{}
-	response, err := privateCloudApi.GetBandWidthMetrics("218030", "AVG", "MONTH", "2017-07-01T00:00:00+00:00", "2017-07-02T00:00:00+00:00")
+	ctx := context.Background()
+	response, err := privateCloudApi.GetBandWidthMetrics(ctx, "218030", "AVG", "MONTH", "2017-07-01T00:00:00+00:00", "2017-07-02T00:00:00+00:00")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -931,7 +963,8 @@ func TestPrivateCloudGetBandWidthMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.GetBandWidthMetrics("218030")
+				ctx := context.Background()
+				return PrivateCloudApi{}.GetBandWidthMetrics(ctx, "218030")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "ACCESS_DENIED",
@@ -947,7 +980,8 @@ func TestPrivateCloudGetBandWidthMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "404", "errorMessage": "Resource 218030 was not found", "userMessage": "Resource with id 218030 not found."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.GetBandWidthMetrics("218030")
+				ctx := context.Background()
+				return PrivateCloudApi{}.GetBandWidthMetrics(ctx, "218030")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "404",
@@ -964,7 +998,8 @@ func TestPrivateCloudGetBandWidthMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.GetBandWidthMetrics("218030")
+				ctx := context.Background()
+				return PrivateCloudApi{}.GetBandWidthMetrics(ctx, "218030")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "SERVER_ERROR",
@@ -980,7 +1015,8 @@ func TestPrivateCloudGetBandWidthMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.GetBandWidthMetrics("218030")
+				ctx := context.Background()
+				return PrivateCloudApi{}.GetBandWidthMetrics(ctx, "218030")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "TEMPORARILY_UNAVAILABLE",
@@ -1022,7 +1058,8 @@ func TestPrivateCloudGetCpuMetrics(t *testing.T) {
 	defer teardown()
 
 	privateCloudApi := PrivateCloudApi{}
-	response, err := privateCloudApi.GetCpuMetrics("218030")
+	ctx := context.Background()
+	response, err := privateCloudApi.GetCpuMetrics(ctx, "218030")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -1069,7 +1106,8 @@ func TestPrivateCloudGetCpuMetricsWithFilter(t *testing.T) {
 	defer teardown()
 
 	privateCloudApi := PrivateCloudApi{}
-	response, err := privateCloudApi.GetCpuMetrics("218030", "MAX", "MONTH", "2017-07-01T00:00:00+00:00", "2017-07-02T00:00:00+00:00")
+	ctx := context.Background()
+	response, err := privateCloudApi.GetCpuMetrics(ctx, "218030", "MAX", "MONTH", "2017-07-01T00:00:00+00:00", "2017-07-02T00:00:00+00:00")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -1096,7 +1134,8 @@ func TestPrivateCloudGetCpuMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.GetCpuMetrics("218030")
+				ctx := context.Background()
+				return PrivateCloudApi{}.GetCpuMetrics(ctx, "218030")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "ACCESS_DENIED",
@@ -1112,7 +1151,8 @@ func TestPrivateCloudGetCpuMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "404", "errorMessage": "Resource 218030 was not found", "userMessage": "Resource with id 218030 not found."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.GetCpuMetrics("218030")
+				ctx := context.Background()
+				return PrivateCloudApi{}.GetCpuMetrics(ctx, "218030")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "404",
@@ -1129,7 +1169,8 @@ func TestPrivateCloudGetCpuMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.GetCpuMetrics("218030")
+				ctx := context.Background()
+				return PrivateCloudApi{}.GetCpuMetrics(ctx, "218030")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "SERVER_ERROR",
@@ -1145,7 +1186,8 @@ func TestPrivateCloudGetCpuMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.GetCpuMetrics("218030")
+				ctx := context.Background()
+				return PrivateCloudApi{}.GetCpuMetrics(ctx, "218030")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "TEMPORARILY_UNAVAILABLE",
@@ -1187,7 +1229,8 @@ func TestPrivateCloudGetMemoryMetrics(t *testing.T) {
 	defer teardown()
 
 	privateCloudApi := PrivateCloudApi{}
-	response, err := privateCloudApi.GetMemoryMetrics("218030")
+	ctx := context.Background()
+	response, err := privateCloudApi.GetMemoryMetrics(ctx, "218030")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -1234,7 +1277,8 @@ func TestPrivateCloudGetMemoryMetricsWithFilter(t *testing.T) {
 	defer teardown()
 
 	privateCloudApi := PrivateCloudApi{}
-	response, err := privateCloudApi.GetMemoryMetrics("218030", "MAX", "MONTH", "2017-07-01T00:00:00+00:00", "2017-07-02T00:00:00+00:00")
+	ctx := context.Background()
+	response, err := privateCloudApi.GetMemoryMetrics(ctx, "218030", "MAX", "MONTH", "2017-07-01T00:00:00+00:00", "2017-07-02T00:00:00+00:00")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -1261,7 +1305,8 @@ func TestPrivateCloudGetMemoryMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.GetMemoryMetrics("218030")
+				ctx := context.Background()
+				return PrivateCloudApi{}.GetMemoryMetrics(ctx, "218030")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "ACCESS_DENIED",
@@ -1277,7 +1322,8 @@ func TestPrivateCloudGetMemoryMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "404", "errorMessage": "Resource 218030 was not found", "userMessage": "Resource with id 218030 not found."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.GetMemoryMetrics("218030")
+				ctx := context.Background()
+				return PrivateCloudApi{}.GetMemoryMetrics(ctx, "218030")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "404",
@@ -1294,7 +1340,8 @@ func TestPrivateCloudGetMemoryMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.GetMemoryMetrics("218030")
+				ctx := context.Background()
+				return PrivateCloudApi{}.GetMemoryMetrics(ctx, "218030")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "SERVER_ERROR",
@@ -1310,7 +1357,8 @@ func TestPrivateCloudGetMemoryMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.GetMemoryMetrics("218030")
+				ctx := context.Background()
+				return PrivateCloudApi{}.GetMemoryMetrics(ctx, "218030")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "TEMPORARILY_UNAVAILABLE",
@@ -1352,7 +1400,8 @@ func TestPrivateCloudGetStorageMetrics(t *testing.T) {
 	defer teardown()
 
 	privateCloudApi := PrivateCloudApi{}
-	response, err := privateCloudApi.GetStorageMetrics("218030")
+	ctx := context.Background()
+	response, err := privateCloudApi.GetStorageMetrics(ctx, "218030")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -1399,7 +1448,8 @@ func TestPrivateCloudGetStorageMetricsWithFilter(t *testing.T) {
 	defer teardown()
 
 	privateCloudApi := PrivateCloudApi{}
-	response, err := privateCloudApi.GetStorageMetrics("218030", "MAX", "MONTH", "2017-07-01T00:00:00+00:00", "2017-07-02T00:00:00+00:00")
+	ctx := context.Background()
+	response, err := privateCloudApi.GetStorageMetrics(ctx, "218030", "MAX", "MONTH", "2017-07-01T00:00:00+00:00", "2017-07-02T00:00:00+00:00")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -1426,7 +1476,8 @@ func TestPrivateCloudGetStorageMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.GetStorageMetrics("218030")
+				ctx := context.Background()
+				return PrivateCloudApi{}.GetStorageMetrics(ctx, "218030")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "ACCESS_DENIED",
@@ -1442,7 +1493,8 @@ func TestPrivateCloudGetStorageMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "404", "errorMessage": "Resource 218030 was not found", "userMessage": "Resource with id 218030 not found."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.GetStorageMetrics("218030")
+				ctx := context.Background()
+				return PrivateCloudApi{}.GetStorageMetrics(ctx, "218030")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "404",
@@ -1459,7 +1511,8 @@ func TestPrivateCloudGetStorageMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.GetStorageMetrics("218030")
+				ctx := context.Background()
+				return PrivateCloudApi{}.GetStorageMetrics(ctx, "218030")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "SERVER_ERROR",
@@ -1475,7 +1528,8 @@ func TestPrivateCloudGetStorageMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateCloudApi{}.GetStorageMetrics("218030")
+				ctx := context.Background()
+				return PrivateCloudApi{}.GetStorageMetrics(ctx, "218030")
 			},
 			ExpectedError: ApiError{
 				ErrorCode:    "TEMPORARILY_UNAVAILABLE",

--- a/private_networking.go
+++ b/private_networking.go
@@ -1,6 +1,7 @@
 package leaseweb
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -30,7 +31,7 @@ func (pna PrivateNetworkingApi) getPath(endpoint string) string {
 	return "/bareMetals/" + PRIVATE_NETWORKING_API_VERSION + endpoint
 }
 
-func (pna PrivateNetworkingApi) List(args ...int) (*PrivateNetworks, error) {
+func (pna PrivateNetworkingApi) List(ctx context.Context, args ...int) (*PrivateNetworks, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -41,51 +42,51 @@ func (pna PrivateNetworkingApi) List(args ...int) (*PrivateNetworks, error) {
 
 	path := pna.getPath("/privateNetworks?" + v.Encode())
 	result := &PrivateNetworks{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (pna PrivateNetworkingApi) Create(name string) (*PrivateNetwork, error) {
+func (pna PrivateNetworkingApi) Create(ctx context.Context, name string) (*PrivateNetwork, error) {
 	payload := map[string]string{
 		"name": name,
 	}
 	path := pna.getPath("/privateNetworks")
 	result := &PrivateNetwork{}
-	if err := doRequest(http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (pna PrivateNetworkingApi) Get(id string) (*PrivateNetwork, error) {
+func (pna PrivateNetworkingApi) Get(ctx context.Context, id string) (*PrivateNetwork, error) {
 	path := pna.getPath("/privateNetworks/" + id)
 	result := &PrivateNetwork{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (pna PrivateNetworkingApi) Update(id, name string) (*PrivateNetwork, error) {
+func (pna PrivateNetworkingApi) Update(ctx context.Context, id, name string) (*PrivateNetwork, error) {
 	payload := map[string]string{
 		"name": name,
 	}
 	path := pna.getPath("/privateNetworks")
 	result := &PrivateNetwork{}
-	if err := doRequest(http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (pna PrivateNetworkingApi) Delete(id string) error {
+func (pna PrivateNetworkingApi) Delete(ctx context.Context, id string) error {
 	path := pna.getPath("/privateNetworks/" + id)
-	return doRequest(http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path)
 }
 
-func (pna PrivateNetworkingApi) ListDhcpReservations(id string, args ...int) (*PrivateNetworkingDhcpReservations, error) {
+func (pna PrivateNetworkingApi) ListDhcpReservations(ctx context.Context, id string, args ...int) (*PrivateNetworkingDhcpReservations, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -96,13 +97,13 @@ func (pna PrivateNetworkingApi) ListDhcpReservations(id string, args ...int) (*P
 
 	path := pna.getPath("/privateNetworks/" + id + "/reservations?" + v.Encode())
 	result := &PrivateNetworkingDhcpReservations{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (pna PrivateNetworkingApi) CreateDhcpReservation(id, ip, mac string, sticky bool) (*PrivateNetworkingDhcpReservation, error) {
+func (pna PrivateNetworkingApi) CreateDhcpReservation(ctx context.Context, id, ip, mac string, sticky bool) (*PrivateNetworkingDhcpReservation, error) {
 	payload := map[string]interface{}{
 		"ip":     ip,
 		"mac":    mac,
@@ -110,13 +111,13 @@ func (pna PrivateNetworkingApi) CreateDhcpReservation(id, ip, mac string, sticky
 	}
 	path := pna.getPath("/privateNetworks/" + id + "/reservations")
 	result := &PrivateNetworkingDhcpReservation{}
-	if err := doRequest(http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (pna PrivateNetworkingApi) DeleteDhcpReservation(id, ip string) error {
+func (pna PrivateNetworkingApi) DeleteDhcpReservation(ctx context.Context, id, ip string) error {
 	path := pna.getPath("/privateNetworks/" + id + "/reservations/" + ip)
-	return doRequest(http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path)
 }

--- a/private_networking_test.go
+++ b/private_networking_test.go
@@ -1,6 +1,7 @@
 package leaseweb
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -31,7 +32,8 @@ func TestPrivateNetworkList(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := PrivateNetworkingApi{}.List()
+	ctx := context.Background()
+	response, err := PrivateNetworkingApi{}.List(ctx)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -71,7 +73,8 @@ func TestPrivateNetworkListPaginate(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := PrivateNetworkingApi{}.List(1)
+	ctx := context.Background()
+	response, err := PrivateNetworkingApi{}.List(ctx, 1)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -99,7 +102,8 @@ func TestPrivateNetworkListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateNetworkingApi{}.List()
+				ctx := context.Background()
+				return PrivateNetworkingApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -116,7 +120,8 @@ func TestPrivateNetworkListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateNetworkingApi{}.List()
+				ctx := context.Background()
+				return PrivateNetworkingApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -133,7 +138,8 @@ func TestPrivateNetworkListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateNetworkingApi{}.List()
+				ctx := context.Background()
+				return PrivateNetworkingApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -150,7 +156,8 @@ func TestPrivateNetworkListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateNetworkingApi{}.List()
+				ctx := context.Background()
+				return PrivateNetworkingApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -177,7 +184,8 @@ func TestPrivateNetworkCreate(t *testing.T) {
 	})
 	defer teardown()
 
-	PrivateNetwork, err := PrivateNetworkingApi{}.Create("production")
+	ctx := context.Background()
+	PrivateNetwork, err := PrivateNetworkingApi{}.Create(ctx, "production")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -200,7 +208,8 @@ func TestPrivateNetworkCreateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateNetworkingApi{}.Create("production")
+				ctx := context.Background()
+				return PrivateNetworkingApi{}.Create(ctx, "production")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -217,7 +226,8 @@ func TestPrivateNetworkCreateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateNetworkingApi{}.Create("production")
+				ctx := context.Background()
+				return PrivateNetworkingApi{}.Create(ctx, "production")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -234,7 +244,8 @@ func TestPrivateNetworkCreateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateNetworkingApi{}.Create("production")
+				ctx := context.Background()
+				return PrivateNetworkingApi{}.Create(ctx, "production")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -251,7 +262,8 @@ func TestPrivateNetworkCreateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateNetworkingApi{}.Create("production")
+				ctx := context.Background()
+				return PrivateNetworkingApi{}.Create(ctx, "production")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -276,7 +288,8 @@ func TestPrivateNetworkGet(t *testing.T) {
 	})
 	defer teardown()
 
-	PrivateNetwork, err := PrivateNetworkingApi{}.Get("12345")
+	ctx := context.Background()
+	PrivateNetwork, err := PrivateNetworkingApi{}.Get(ctx, "12345")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -297,7 +310,8 @@ func TestPrivateNetworkGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateNetworkingApi{}.Get("12345")
+				ctx := context.Background()
+				return PrivateNetworkingApi{}.Get(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -314,7 +328,8 @@ func TestPrivateNetworkGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateNetworkingApi{}.Get("12345")
+				ctx := context.Background()
+				return PrivateNetworkingApi{}.Get(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -331,7 +346,8 @@ func TestPrivateNetworkGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateNetworkingApi{}.Get("12345")
+				ctx := context.Background()
+				return PrivateNetworkingApi{}.Get(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -348,7 +364,8 @@ func TestPrivateNetworkGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateNetworkingApi{}.Get("12345")
+				ctx := context.Background()
+				return PrivateNetworkingApi{}.Get(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -375,7 +392,8 @@ func TestPrivateNetworkUpdate(t *testing.T) {
 	})
 	defer teardown()
 
-	PrivateNetwork, err := PrivateNetworkingApi{}.Update("12345", "production")
+	ctx := context.Background()
+	PrivateNetwork, err := PrivateNetworkingApi{}.Update(ctx, "12345", "production")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -398,7 +416,8 @@ func TestPrivateNetworkUpdateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateNetworkingApi{}.Update("12345", "production")
+				ctx := context.Background()
+				return PrivateNetworkingApi{}.Update(ctx, "12345", "production")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -415,7 +434,8 @@ func TestPrivateNetworkUpdateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateNetworkingApi{}.Update("12345", "production")
+				ctx := context.Background()
+				return PrivateNetworkingApi{}.Update(ctx, "12345", "production")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -432,7 +452,8 @@ func TestPrivateNetworkUpdateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateNetworkingApi{}.Update("12345", "production")
+				ctx := context.Background()
+				return PrivateNetworkingApi{}.Update(ctx, "12345", "production")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -449,7 +470,8 @@ func TestPrivateNetworkUpdateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateNetworkingApi{}.Update("12345", "production")
+				ctx := context.Background()
+				return PrivateNetworkingApi{}.Update(ctx, "12345", "production")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -469,7 +491,8 @@ func TestPrivateNetworkDelete(t *testing.T) {
 	})
 	defer teardown()
 
-	err := PrivateNetworkingApi{}.Delete("12345")
+	ctx := context.Background()
+	err := PrivateNetworkingApi{}.Delete(ctx, "12345")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -486,7 +509,8 @@ func TestPrivateNetworkDeleteServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, PrivateNetworkingApi{}.Delete("12345")
+				ctx := context.Background()
+				return nil, PrivateNetworkingApi{}.Delete(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -503,7 +527,8 @@ func TestPrivateNetworkDeleteServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, PrivateNetworkingApi{}.Delete("12345")
+				ctx := context.Background()
+				return nil, PrivateNetworkingApi{}.Delete(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -520,7 +545,8 @@ func TestPrivateNetworkDeleteServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, PrivateNetworkingApi{}.Delete("12345")
+				ctx := context.Background()
+				return nil, PrivateNetworkingApi{}.Delete(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -537,7 +563,8 @@ func TestPrivateNetworkDeleteServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, PrivateNetworkingApi{}.Delete("12345")
+				ctx := context.Background()
+				return nil, PrivateNetworkingApi{}.Delete(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -570,7 +597,8 @@ func TestPrivateNetworkListDhcpReservations(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := PrivateNetworkingApi{}.ListDhcpReservations("12345")
+	ctx := context.Background()
+	response, err := PrivateNetworkingApi{}.ListDhcpReservations(ctx, "12345")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -606,7 +634,8 @@ func TestPrivateNetworkListDhcpReservationsPaginate(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := PrivateNetworkingApi{}.ListDhcpReservations("12345", 1)
+	ctx := context.Background()
+	response, err := PrivateNetworkingApi{}.ListDhcpReservations(ctx, "12345", 1)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -632,7 +661,8 @@ func TestPrivateNetworkListDhcpReservationsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateNetworkingApi{}.ListDhcpReservations("12345")
+				ctx := context.Background()
+				return PrivateNetworkingApi{}.ListDhcpReservations(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -649,7 +679,8 @@ func TestPrivateNetworkListDhcpReservationsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateNetworkingApi{}.ListDhcpReservations("12345")
+				ctx := context.Background()
+				return PrivateNetworkingApi{}.ListDhcpReservations(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -666,7 +697,8 @@ func TestPrivateNetworkListDhcpReservationsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateNetworkingApi{}.ListDhcpReservations("12345")
+				ctx := context.Background()
+				return PrivateNetworkingApi{}.ListDhcpReservations(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -683,7 +715,8 @@ func TestPrivateNetworkListDhcpReservationsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateNetworkingApi{}.ListDhcpReservations("12345")
+				ctx := context.Background()
+				return PrivateNetworkingApi{}.ListDhcpReservations(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -707,7 +740,8 @@ func TestPrivateNetworkCreateDhcpReservation(t *testing.T) {
 	})
 	defer teardown()
 
-	DhcpReservation, err := PrivateNetworkingApi{}.CreateDhcpReservation("12345", "127.0.0.1", "d8:87:03:52:0a:0f", true)
+	ctx := context.Background()
+	DhcpReservation, err := PrivateNetworkingApi{}.CreateDhcpReservation(ctx, "12345", "127.0.0.1", "d8:87:03:52:0a:0f", true)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -727,7 +761,8 @@ func TestPrivateNetworkCreateDhcpReservationServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateNetworkingApi{}.CreateDhcpReservation("12345", "127.0.0.1", "d8:87:03:52:0a:0f", true)
+				ctx := context.Background()
+				return PrivateNetworkingApi{}.CreateDhcpReservation(ctx, "12345", "127.0.0.1", "d8:87:03:52:0a:0f", true)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -744,7 +779,8 @@ func TestPrivateNetworkCreateDhcpReservationServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateNetworkingApi{}.CreateDhcpReservation("12345", "127.0.0.1", "d8:87:03:52:0a:0f", true)
+				ctx := context.Background()
+				return PrivateNetworkingApi{}.CreateDhcpReservation(ctx, "12345", "127.0.0.1", "d8:87:03:52:0a:0f", true)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -761,7 +797,8 @@ func TestPrivateNetworkCreateDhcpReservationServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateNetworkingApi{}.CreateDhcpReservation("12345", "127.0.0.1", "d8:87:03:52:0a:0f", true)
+				ctx := context.Background()
+				return PrivateNetworkingApi{}.CreateDhcpReservation(ctx, "12345", "127.0.0.1", "d8:87:03:52:0a:0f", true)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -778,7 +815,8 @@ func TestPrivateNetworkCreateDhcpReservationServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return PrivateNetworkingApi{}.CreateDhcpReservation("12345", "127.0.0.1", "d8:87:03:52:0a:0f", true)
+				ctx := context.Background()
+				return PrivateNetworkingApi{}.CreateDhcpReservation(ctx, "12345", "127.0.0.1", "d8:87:03:52:0a:0f", true)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -798,7 +836,8 @@ func TestPrivateNetworkDeleteDhcpReservation(t *testing.T) {
 	})
 	defer teardown()
 
-	err := PrivateNetworkingApi{}.DeleteDhcpReservation("12345", "127.0.0.1")
+	ctx := context.Background()
+	err := PrivateNetworkingApi{}.DeleteDhcpReservation(ctx, "12345", "127.0.0.1")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -815,7 +854,8 @@ func TestPrivateNetworkDeleteDhcpReservationServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, PrivateNetworkingApi{}.DeleteDhcpReservation("12345", "127.0.0.1")
+				ctx := context.Background()
+				return nil, PrivateNetworkingApi{}.DeleteDhcpReservation(ctx, "12345", "127.0.0.1")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -832,7 +872,8 @@ func TestPrivateNetworkDeleteDhcpReservationServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, PrivateNetworkingApi{}.DeleteDhcpReservation("12345", "127.0.0.1")
+				ctx := context.Background()
+				return nil, PrivateNetworkingApi{}.DeleteDhcpReservation(ctx, "12345", "127.0.0.1")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -849,7 +890,8 @@ func TestPrivateNetworkDeleteDhcpReservationServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, PrivateNetworkingApi{}.DeleteDhcpReservation("12345", "127.0.0.1")
+				ctx := context.Background()
+				return nil, PrivateNetworkingApi{}.DeleteDhcpReservation(ctx, "12345", "127.0.0.1")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -866,7 +908,8 @@ func TestPrivateNetworkDeleteDhcpReservationServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, PrivateNetworkingApi{}.DeleteDhcpReservation("12345", "127.0.0.1")
+				ctx := context.Background()
+				return nil, PrivateNetworkingApi{}.DeleteDhcpReservation(ctx, "12345", "127.0.0.1")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",

--- a/remote_management.go
+++ b/remote_management.go
@@ -1,6 +1,7 @@
 package leaseweb
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -25,13 +26,13 @@ func (rma RemoteManagementApi) getPath(endpoint string) string {
 	return "/bareMetals/" + REMOTE_MANAGEMENT_API_VERSION + endpoint
 }
 
-func (rma RemoteManagementApi) ChangeCredentials(password string) error {
+func (rma RemoteManagementApi) ChangeCredentials(ctx context.Context, password string) error {
 	payload := map[string]string{password: password}
 	path := rma.getPath("/remoteManagement/changeCredentials")
-	return doRequest(http.MethodPost, path, nil, payload)
+	return doRequest(ctx, http.MethodPost, path, nil, payload)
 }
 
-func (rma RemoteManagementApi) ListProfiles(args ...int) (*RemoteManagementProfiles, error) {
+func (rma RemoteManagementApi) ListProfiles(ctx context.Context, args ...int) (*RemoteManagementProfiles, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -42,7 +43,7 @@ func (rma RemoteManagementApi) ListProfiles(args ...int) (*RemoteManagementProfi
 
 	path := rma.getPath("/remoteManagement/profiles" + v.Encode())
 	result := &RemoteManagementProfiles{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/remote_management_test.go
+++ b/remote_management_test.go
@@ -1,6 +1,7 @@
 package leaseweb
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -17,7 +18,8 @@ func TestRemoteManagementChangeCredentials(t *testing.T) {
 	defer teardown()
 
 	remoteManagementApi := RemoteManagementApi{}
-	err := remoteManagementApi.ChangeCredentials("new password")
+	ctx := context.Background()
+	err := remoteManagementApi.ChangeCredentials(ctx, "new password")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -34,7 +36,8 @@ func TestRemoteManagementTestChangeCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, RemoteManagementApi{}.ChangeCredentials("new password")
+				ctx := context.Background()
+				return nil, RemoteManagementApi{}.ChangeCredentials(ctx, "new password")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -51,7 +54,8 @@ func TestRemoteManagementTestChangeCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, RemoteManagementApi{}.ChangeCredentials("new password")
+				ctx := context.Background()
+				return nil, RemoteManagementApi{}.ChangeCredentials(ctx, "new password")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -68,7 +72,8 @@ func TestRemoteManagementTestChangeCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, RemoteManagementApi{}.ChangeCredentials("new password")
+				ctx := context.Background()
+				return nil, RemoteManagementApi{}.ChangeCredentials(ctx, "new password")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -85,7 +90,8 @@ func TestRemoteManagementTestChangeCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, RemoteManagementApi{}.ChangeCredentials("new password")
+				ctx := context.Background()
+				return nil, RemoteManagementApi{}.ChangeCredentials(ctx, "new password")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -124,7 +130,8 @@ func TestRemoteManagementListProfiles(t *testing.T) {
 	defer teardown()
 
 	remoteManagementApi := RemoteManagementApi{}
-	response, err := remoteManagementApi.ListProfiles()
+	ctx := context.Background()
+	response, err := remoteManagementApi.ListProfiles(ctx)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -167,7 +174,8 @@ func TestRemoteManagementListProfilesPaginate(t *testing.T) {
 	defer teardown()
 
 	remoteManagementApi := RemoteManagementApi{}
-	response, err := remoteManagementApi.ListProfiles(1)
+	ctx := context.Background()
+	response, err := remoteManagementApi.ListProfiles(ctx, 1)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -195,7 +203,8 @@ func TestRemoteManagementTestListProfilesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return RemoteManagementApi{}.ListProfiles()
+				ctx := context.Background()
+				return RemoteManagementApi{}.ListProfiles(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -212,7 +221,8 @@ func TestRemoteManagementTestListProfilesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "403", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return RemoteManagementApi{}.ListProfiles()
+				ctx := context.Background()
+				return RemoteManagementApi{}.ListProfiles(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -229,7 +239,8 @@ func TestRemoteManagementTestListProfilesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "500", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return RemoteManagementApi{}.ListProfiles()
+				ctx := context.Background()
+				return RemoteManagementApi{}.ListProfiles(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -246,7 +257,8 @@ func TestRemoteManagementTestListProfilesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "503", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return RemoteManagementApi{}.ListProfiles()
+				ctx := context.Background()
+				return RemoteManagementApi{}.ListProfiles(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",

--- a/rest.go
+++ b/rest.go
@@ -1,6 +1,7 @@
 package leaseweb
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -78,7 +79,7 @@ func getBaseUrl() string {
 	return DEFAULT_BASE_URL
 }
 
-func doRequest(method string, path string, args ...interface{}) error {
+func doRequest(ctx context.Context, method string, path string, args ...interface{}) error {
 	url := getBaseUrl() + path
 
 	var tmpPayload io.Reader
@@ -92,7 +93,7 @@ func doRequest(method string, path string, args ...interface{}) error {
 		}
 	}
 
-	req, err := http.NewRequest(method, url, tmpPayload)
+	req, err := http.NewRequestWithContext(ctx, method, url, tmpPayload)
 	if err != nil {
 		return err
 	}

--- a/services.go
+++ b/services.go
@@ -1,6 +1,7 @@
 package leaseweb
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -52,7 +53,7 @@ func (sa ServicesApi) getPath(endpoint string) string {
 	return "/services/" + SERVICES_API_VERSION + endpoint
 }
 
-func (sa ServicesApi) List(args ...int) (*Services, error) {
+func (sa ServicesApi) List(ctx context.Context, args ...int) (*Services, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -63,40 +64,40 @@ func (sa ServicesApi) List(args ...int) (*Services, error) {
 
 	path := sa.getPath("/services?" + v.Encode())
 	result := &Services{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (sa ServicesApi) ListCancellationReasons() (*ServicesCancellationReasons, error) {
+func (sa ServicesApi) ListCancellationReasons(ctx context.Context) (*ServicesCancellationReasons, error) {
 	path := sa.getPath("/services/cancellationReasons")
 	result := &ServicesCancellationReasons{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (sa ServicesApi) Get(id string) (*Service, error) {
+func (sa ServicesApi) Get(ctx context.Context, id string) (*Service, error) {
 	path := sa.getPath("/services/" + id)
 	result := &Service{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (sa ServicesApi) Cancel(id, reason, reasonCode string) error {
+func (sa ServicesApi) Cancel(ctx context.Context, id, reason, reasonCode string) error {
 	payload := map[string]string{
 		"reason":     reason,
 		"reasonCode": reasonCode,
 	}
 	path := sa.getPath("/services/" + id + "/cancel")
-	return doRequest(http.MethodPost, path, nil, payload)
+	return doRequest(ctx, http.MethodPost, path, nil, payload)
 }
 
-func (sa ServicesApi) Uncancel(id string) error {
+func (sa ServicesApi) Uncancel(ctx context.Context, id string) error {
 	path := sa.getPath("/services/" + id + "/uncancel")
-	return doRequest(http.MethodPost, path)
+	return doRequest(ctx, http.MethodPost, path)
 }

--- a/services_test.go
+++ b/services_test.go
@@ -1,6 +1,7 @@
 package leaseweb
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -61,7 +62,8 @@ func TestServicesList(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := ServicesApi{}.List()
+	ctx := context.Background()
+	response, err := ServicesApi{}.List(ctx)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -144,7 +146,8 @@ func TestServicesListPaginate(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := ServicesApi{}.List(1)
+	ctx := context.Background()
+	response, err := ServicesApi{}.List(ctx, 1)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -185,7 +188,8 @@ func TestServicesListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return ServicesApi{}.List()
+				ctx := context.Background()
+				return ServicesApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -202,7 +206,8 @@ func TestServicesListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return ServicesApi{}.List()
+				ctx := context.Background()
+				return ServicesApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -219,7 +224,8 @@ func TestServicesListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return ServicesApi{}.List()
+				ctx := context.Background()
+				return ServicesApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -236,7 +242,8 @@ func TestServicesListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return ServicesApi{}.List()
+				ctx := context.Background()
+				return ServicesApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -271,7 +278,8 @@ func TestServicesListCancellationReasons(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := ServicesApi{}.ListCancellationReasons()
+	ctx := context.Background()
+	response, err := ServicesApi{}.ListCancellationReasons(ctx)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -297,7 +305,8 @@ func TestServicesListCancellationReasonsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return ServicesApi{}.ListCancellationReasons()
+				ctx := context.Background()
+				return ServicesApi{}.ListCancellationReasons(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -314,7 +323,8 @@ func TestServicesListCancellationReasonsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return ServicesApi{}.ListCancellationReasons()
+				ctx := context.Background()
+				return ServicesApi{}.ListCancellationReasons(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -331,7 +341,8 @@ func TestServicesListCancellationReasonsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return ServicesApi{}.ListCancellationReasons()
+				ctx := context.Background()
+				return ServicesApi{}.ListCancellationReasons(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -348,7 +359,8 @@ func TestServicesListCancellationReasonsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return ServicesApi{}.ListCancellationReasons()
+				ctx := context.Background()
+				return ServicesApi{}.ListCancellationReasons(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -387,7 +399,8 @@ func TestServicesGet(t *testing.T) {
 	})
 	defer teardown()
 
-	Service, err := ServicesApi{}.Get("12345")
+	ctx := context.Background()
+	Service, err := ServicesApi{}.Get(ctx, "12345")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -423,7 +436,8 @@ func TestServicesGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return ServicesApi{}.Get("12345")
+				ctx := context.Background()
+				return ServicesApi{}.Get(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -440,7 +454,8 @@ func TestServicesGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return ServicesApi{}.Get("12345")
+				ctx := context.Background()
+				return ServicesApi{}.Get(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -457,7 +472,8 @@ func TestServicesGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return ServicesApi{}.Get("12345")
+				ctx := context.Background()
+				return ServicesApi{}.Get(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -474,7 +490,8 @@ func TestServicesGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return ServicesApi{}.Get("12345")
+				ctx := context.Background()
+				return ServicesApi{}.Get(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -494,7 +511,8 @@ func TestServicesCancel(t *testing.T) {
 	})
 	defer teardown()
 
-	err := ServicesApi{}.Cancel("12345", "reason", "reason code")
+	ctx := context.Background()
+	err := ServicesApi{}.Cancel(ctx, "12345", "reason", "reason code")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -511,7 +529,8 @@ func TestServicesCancelServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, ServicesApi{}.Cancel("12345", "reason", "reason code")
+				ctx := context.Background()
+				return nil, ServicesApi{}.Cancel(ctx, "12345", "reason", "reason code")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -528,7 +547,8 @@ func TestServicesCancelServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, ServicesApi{}.Cancel("12345", "reason", "reason code")
+				ctx := context.Background()
+				return nil, ServicesApi{}.Cancel(ctx, "12345", "reason", "reason code")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -545,7 +565,8 @@ func TestServicesCancelServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, ServicesApi{}.Cancel("12345", "reason", "reason code")
+				ctx := context.Background()
+				return nil, ServicesApi{}.Cancel(ctx, "12345", "reason", "reason code")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -562,7 +583,8 @@ func TestServicesCancelServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, ServicesApi{}.Cancel("12345", "reason", "reason code")
+				ctx := context.Background()
+				return nil, ServicesApi{}.Cancel(ctx, "12345", "reason", "reason code")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -582,7 +604,8 @@ func TestServicesUncancel(t *testing.T) {
 	})
 	defer teardown()
 
-	err := ServicesApi{}.Uncancel("12345")
+	ctx := context.Background()
+	err := ServicesApi{}.Uncancel(ctx, "12345")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -599,7 +622,8 @@ func TestServicesUncancelServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, ServicesApi{}.Uncancel("12345")
+				ctx := context.Background()
+				return nil, ServicesApi{}.Uncancel(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -616,7 +640,8 @@ func TestServicesUncancelServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, ServicesApi{}.Uncancel("12345")
+				ctx := context.Background()
+				return nil, ServicesApi{}.Uncancel(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -633,7 +658,8 @@ func TestServicesUncancelServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, ServicesApi{}.Uncancel("12345")
+				ctx := context.Background()
+				return nil, ServicesApi{}.Uncancel(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -650,7 +676,8 @@ func TestServicesUncancelServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, ServicesApi{}.Uncancel("12345")
+				ctx := context.Background()
+				return nil, ServicesApi{}.Uncancel(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",

--- a/virtual_server.go
+++ b/virtual_server.go
@@ -1,6 +1,7 @@
 package leaseweb
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -59,7 +60,7 @@ func (vsa VirtualServerApi) getPath(endpoint string) string {
 	return "/cloud/" + VIRTUAL_SERVER_API_VERSION + endpoint
 }
 
-func (vsa VirtualServerApi) List(args ...int) (*VirtualServers, error) {
+func (vsa VirtualServerApi) List(ctx context.Context, args ...int) (*VirtualServers, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -70,75 +71,75 @@ func (vsa VirtualServerApi) List(args ...int) (*VirtualServers, error) {
 
 	path := vsa.getPath("/virtualServers?" + v.Encode())
 	result := &VirtualServers{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (vsa VirtualServerApi) Get(virtualServerId string) (*VirtualServer, error) {
+func (vsa VirtualServerApi) Get(ctx context.Context, virtualServerId string) (*VirtualServer, error) {
 	path := vsa.getPath("/virtualServers/" + virtualServerId)
 	result := &VirtualServer{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (vsa VirtualServerApi) Update(virtualServerId, reference string) (*VirtualServer, error) {
+func (vsa VirtualServerApi) Update(ctx context.Context, virtualServerId, reference string) (*VirtualServer, error) {
 	payload := map[string]string{"reference": reference}
 	path := vsa.getPath("/virtualServers/" + virtualServerId)
 	result := &VirtualServer{}
-	if err := doRequest(http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (vsa VirtualServerApi) PowerOn(virtualServerId string) (*VirtualServerResult, error) {
+func (vsa VirtualServerApi) PowerOn(ctx context.Context, virtualServerId string) (*VirtualServerResult, error) {
 	path := vsa.getPath("/virtualServers/" + virtualServerId + "/powerOn")
 	result := &VirtualServerResult{}
-	if err := doRequest(http.MethodPost, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (vsa VirtualServerApi) PowerOff(virtualServerId string) (*VirtualServerResult, error) {
+func (vsa VirtualServerApi) PowerOff(ctx context.Context, virtualServerId string) (*VirtualServerResult, error) {
 	path := vsa.getPath("/virtualServers/" + virtualServerId + "/powerOff")
 	result := &VirtualServerResult{}
-	if err := doRequest(http.MethodPost, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (vsa VirtualServerApi) Reboot(virtualServerId string) (*VirtualServerResult, error) {
+func (vsa VirtualServerApi) Reboot(ctx context.Context, virtualServerId string) (*VirtualServerResult, error) {
 	path := vsa.getPath("/virtualServers/" + virtualServerId + "/reboot")
 	result := &VirtualServerResult{}
-	if err := doRequest(http.MethodPost, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (vsa VirtualServerApi) Reinstall(virtualServerId, operatingSystemId string) (*VirtualServerResult, error) {
+func (vsa VirtualServerApi) Reinstall(ctx context.Context, virtualServerId, operatingSystemId string) (*VirtualServerResult, error) {
 	payload := map[string]string{"operatingSystemId": operatingSystemId}
 	path := vsa.getPath("/virtualServers/" + virtualServerId + "/reinstall")
 	result := &VirtualServerResult{}
-	if err := doRequest(http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (vsa VirtualServerApi) UpdateCredential(virtualServerId, username, credentialType, password string) error {
+func (vsa VirtualServerApi) UpdateCredential(ctx context.Context, virtualServerId, username, credentialType, password string) error {
 	payload := map[string]string{"username": username, "type": credentialType, "password": password}
 	path := vsa.getPath("/virtualServers/" + virtualServerId + "/credentials")
-	return doRequest(http.MethodPut, path, nil, payload)
+	return doRequest(ctx, http.MethodPut, path, nil, payload)
 }
 
-func (vsa VirtualServerApi) ListCredentials(virtualServerId, credentialType string, args ...int) (*Credentials, error) {
+func (vsa VirtualServerApi) ListCredentials(ctx context.Context, virtualServerId, credentialType string, args ...int) (*Credentials, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -149,22 +150,22 @@ func (vsa VirtualServerApi) ListCredentials(virtualServerId, credentialType stri
 
 	path := vsa.getPath("/virtualServers/" + virtualServerId + "/credentials/" + credentialType + "?" + v.Encode())
 	result := &Credentials{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (vsa VirtualServerApi) GetCredential(virtualServerId, username, credentialType string) (*Credential, error) {
+func (vsa VirtualServerApi) GetCredential(ctx context.Context, virtualServerId, username, credentialType string) (*Credential, error) {
 	path := vsa.getPath("/virtualServers/" + virtualServerId + "/credentials/" + credentialType + "/" + username)
 	result := &Credential{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (vsa VirtualServerApi) GetDataTrafficMetrics(virtualServerId string, args ...interface{}) (*DataTrafficMetricsV2, error) {
+func (vsa VirtualServerApi) GetDataTrafficMetrics(ctx context.Context, virtualServerId string, args ...interface{}) (*DataTrafficMetricsV2, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("granularity", fmt.Sprint(args[0]))
@@ -181,13 +182,13 @@ func (vsa VirtualServerApi) GetDataTrafficMetrics(virtualServerId string, args .
 
 	path := vsa.getPath("/virtualServers/" + virtualServerId + "/metrics/datatraffic?" + v.Encode())
 	result := &DataTrafficMetricsV2{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (vsa VirtualServerApi) ListTemplates(virtualServerId string, args ...int) (*VirtualServerTemplates, error) {
+func (vsa VirtualServerApi) ListTemplates(ctx context.Context, virtualServerId string, args ...int) (*VirtualServerTemplates, error) {
 	v := url.Values{}
 	if len(args) >= 1 {
 		v.Add("offset", fmt.Sprint(args[0]))
@@ -198,7 +199,7 @@ func (vsa VirtualServerApi) ListTemplates(virtualServerId string, args ...int) (
 
 	path := vsa.getPath("/virtualServers/" + virtualServerId + "/templates")
 	result := &VirtualServerTemplates{}
-	if err := doRequest(http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/virtual_server_test.go
+++ b/virtual_server_test.go
@@ -1,6 +1,7 @@
 package leaseweb
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -112,7 +113,8 @@ func TestVirtualServerList(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := VirtualServerApi{}.List()
+	ctx := context.Background()
+	response, err := VirtualServerApi{}.List(ctx)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -238,7 +240,8 @@ func TestVirtualServerListPaginate(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := VirtualServerApi{}.List(1)
+	ctx := context.Background()
+	response, err := VirtualServerApi{}.List(ctx, 1)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -287,7 +290,8 @@ func TestVirtualServerListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.List()
+				ctx := context.Background()
+				return VirtualServerApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -304,7 +308,8 @@ func TestVirtualServerListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.List()
+				ctx := context.Background()
+				return VirtualServerApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -321,7 +326,8 @@ func TestVirtualServerListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.List()
+				ctx := context.Background()
+				return VirtualServerApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -338,7 +344,8 @@ func TestVirtualServerListServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.List()
+				ctx := context.Background()
+				return VirtualServerApi{}.List(ctx)
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -399,7 +406,8 @@ func TestVirtualServerGet(t *testing.T) {
 	})
 	defer teardown()
 
-	virtualServer, err := VirtualServerApi{}.Get("123456")
+	ctx := context.Background()
+	virtualServer, err := VirtualServerApi{}.Get(ctx, "123456")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -442,7 +450,8 @@ func TestVirtualServerGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.Get("123456")
+				ctx := context.Background()
+				return VirtualServerApi{}.Get(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -459,7 +468,8 @@ func TestVirtualServerGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.Get("123456")
+				ctx := context.Background()
+				return VirtualServerApi{}.Get(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -476,7 +486,8 @@ func TestVirtualServerGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource '218030' was not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.Get("123456")
+				ctx := context.Background()
+				return VirtualServerApi{}.Get(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -493,7 +504,8 @@ func TestVirtualServerGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.Get("123456")
+				ctx := context.Background()
+				return VirtualServerApi{}.Get(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -510,7 +522,8 @@ func TestVirtualServerGetServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.Get("123456")
+				ctx := context.Background()
+				return VirtualServerApi{}.Get(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -571,7 +584,8 @@ func TestVirtualServerUpdate(t *testing.T) {
 	})
 	defer teardown()
 
-	virtualServer, err := VirtualServerApi{}.Update("123456", "Web server")
+	ctx := context.Background()
+	virtualServer, err := VirtualServerApi{}.Update(ctx, "123456", "Web server")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -614,7 +628,8 @@ func TestVirtualServerUpdateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.Update("123456", "Web server")
+				ctx := context.Background()
+				return VirtualServerApi{}.Update(ctx, "123456", "Web server")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -631,7 +646,8 @@ func TestVirtualServerUpdateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.Update("123456", "Web server")
+				ctx := context.Background()
+				return VirtualServerApi{}.Update(ctx, "123456", "Web server")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -648,7 +664,8 @@ func TestVirtualServerUpdateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource '218030' was not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.Update("123456", "Web server")
+				ctx := context.Background()
+				return VirtualServerApi{}.Update(ctx, "123456", "Web server")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -665,7 +682,8 @@ func TestVirtualServerUpdateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.Update("123456", "Web server")
+				ctx := context.Background()
+				return VirtualServerApi{}.Update(ctx, "123456", "Web server")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -682,7 +700,8 @@ func TestVirtualServerUpdateServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.Update("123456", "Web server")
+				ctx := context.Background()
+				return VirtualServerApi{}.Update(ctx, "123456", "Web server")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -698,7 +717,7 @@ func TestVirtualServerPowerOff(t *testing.T) {
 	setup(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, testApiKey, r.Header.Get("x-lsw-auth"))
-		fmt.Fprintf(w, `{			
+		fmt.Fprintf(w, `{
 			"id": "cs01.237daad0-2aed-4260-b0e4-488d9cd55607",
 			"name": "virtualServers.powerOff",
 			"status": "PENDING",
@@ -707,7 +726,8 @@ func TestVirtualServerPowerOff(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := VirtualServerApi{}.PowerOff("123456")
+	ctx := context.Background()
+	resp, err := VirtualServerApi{}.PowerOff(ctx, "123456")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -728,7 +748,8 @@ func TestVirtualServerPowerOffServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.PowerOff("123456")
+				ctx := context.Background()
+				return VirtualServerApi{}.PowerOff(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -745,7 +766,8 @@ func TestVirtualServerPowerOffServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.PowerOff("123456")
+				ctx := context.Background()
+				return VirtualServerApi{}.PowerOff(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -762,7 +784,8 @@ func TestVirtualServerPowerOffServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource '218030' was not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.PowerOff("123456")
+				ctx := context.Background()
+				return VirtualServerApi{}.PowerOff(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -779,7 +802,8 @@ func TestVirtualServerPowerOffServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.PowerOff("123456")
+				ctx := context.Background()
+				return VirtualServerApi{}.PowerOff(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -796,7 +820,8 @@ func TestVirtualServerPowerOffServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.PowerOff("123456")
+				ctx := context.Background()
+				return VirtualServerApi{}.PowerOff(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -812,7 +837,7 @@ func TestVirtualServerPowerOn(t *testing.T) {
 	setup(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, testApiKey, r.Header.Get("x-lsw-auth"))
-		fmt.Fprintf(w, `{			
+		fmt.Fprintf(w, `{
 			"id": "cs01.237daad0-2aed-4260-b0e4-488d9cd55607",
 			"name": "virtualServers.powerOn",
 			"status": "PENDING",
@@ -821,7 +846,8 @@ func TestVirtualServerPowerOn(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := VirtualServerApi{}.PowerOn("123456")
+	ctx := context.Background()
+	resp, err := VirtualServerApi{}.PowerOn(ctx, "123456")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -842,7 +868,8 @@ func TestVirtualServerPowerOnServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.PowerOn("123456")
+				ctx := context.Background()
+				return VirtualServerApi{}.PowerOn(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -859,7 +886,8 @@ func TestVirtualServerPowerOnServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.PowerOn("123456")
+				ctx := context.Background()
+				return VirtualServerApi{}.PowerOn(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -876,7 +904,8 @@ func TestVirtualServerPowerOnServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource '218030' was not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.PowerOn("123456")
+				ctx := context.Background()
+				return VirtualServerApi{}.PowerOn(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -893,7 +922,8 @@ func TestVirtualServerPowerOnServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.PowerOn("123456")
+				ctx := context.Background()
+				return VirtualServerApi{}.PowerOn(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -910,7 +940,8 @@ func TestVirtualServerPowerOnServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.PowerOn("123456")
+				ctx := context.Background()
+				return VirtualServerApi{}.PowerOn(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -926,7 +957,7 @@ func TestVirtualServerReboot(t *testing.T) {
 	setup(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, testApiKey, r.Header.Get("x-lsw-auth"))
-		fmt.Fprintf(w, `{			
+		fmt.Fprintf(w, `{
 			"id": "cs01.237daad0-2aed-4260-b0e4-488d9cd55607",
 			"name": "virtualServers.reboot",
 			"status": "PENDING",
@@ -935,7 +966,8 @@ func TestVirtualServerReboot(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := VirtualServerApi{}.Reboot("123456")
+	ctx := context.Background()
+	resp, err := VirtualServerApi{}.Reboot(ctx, "123456")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -956,7 +988,8 @@ func TestVirtualServerRebootServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.Reboot("123456")
+				ctx := context.Background()
+				return VirtualServerApi{}.Reboot(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -973,7 +1006,8 @@ func TestVirtualServerRebootServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.Reboot("123456")
+				ctx := context.Background()
+				return VirtualServerApi{}.Reboot(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -990,7 +1024,8 @@ func TestVirtualServerRebootServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource '218030' was not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.Reboot("123456")
+				ctx := context.Background()
+				return VirtualServerApi{}.Reboot(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1007,7 +1042,8 @@ func TestVirtualServerRebootServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.Reboot("123456")
+				ctx := context.Background()
+				return VirtualServerApi{}.Reboot(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1024,7 +1060,8 @@ func TestVirtualServerRebootServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.Reboot("123456")
+				ctx := context.Background()
+				return VirtualServerApi{}.Reboot(ctx, "123456")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1040,7 +1077,7 @@ func TestVirtualServerReinstall(t *testing.T) {
 	setup(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, testApiKey, r.Header.Get("x-lsw-auth"))
-		fmt.Fprintf(w, `{			
+		fmt.Fprintf(w, `{
 			"id": "cs01.237daad0-2aed-4260-b0e4-488d9cd55607",
 			"name": "virtualServers.reinstall",
 			"status": "PENDING",
@@ -1049,7 +1086,8 @@ func TestVirtualServerReinstall(t *testing.T) {
 	})
 	defer teardown()
 
-	resp, err := VirtualServerApi{}.Reinstall("123456", "CENTOS_7_64_PLESK")
+	ctx := context.Background()
+	resp, err := VirtualServerApi{}.Reinstall(ctx, "123456", "CENTOS_7_64_PLESK")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -1070,7 +1108,8 @@ func TestVirtualServerReinstallServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.Reinstall("123456", "CENTOS_7_64_PLESK")
+				ctx := context.Background()
+				return VirtualServerApi{}.Reinstall(ctx, "123456", "CENTOS_7_64_PLESK")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1087,7 +1126,8 @@ func TestVirtualServerReinstallServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.Reinstall("123456", "CENTOS_7_64_PLESK")
+				ctx := context.Background()
+				return VirtualServerApi{}.Reinstall(ctx, "123456", "CENTOS_7_64_PLESK")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1104,7 +1144,8 @@ func TestVirtualServerReinstallServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource '218030' was not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.Reinstall("123456", "CENTOS_7_64_PLESK")
+				ctx := context.Background()
+				return VirtualServerApi{}.Reinstall(ctx, "123456", "CENTOS_7_64_PLESK")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1121,7 +1162,8 @@ func TestVirtualServerReinstallServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.Reinstall("123456", "CENTOS_7_64_PLESK")
+				ctx := context.Background()
+				return VirtualServerApi{}.Reinstall(ctx, "123456", "CENTOS_7_64_PLESK")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1138,7 +1180,8 @@ func TestVirtualServerReinstallServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.Reinstall("123456", "CENTOS_7_64_PLESK")
+				ctx := context.Background()
+				return VirtualServerApi{}.Reinstall(ctx, "123456", "CENTOS_7_64_PLESK")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1162,7 +1205,8 @@ func TestVirtualServerUpdateCredential(t *testing.T) {
 	})
 	defer teardown()
 
-	err := VirtualServerApi{}.UpdateCredential("12345", "OPERATING_SYSTEM", "admin", "new password")
+	ctx := context.Background()
+	err := VirtualServerApi{}.UpdateCredential(ctx, "12345", "OPERATING_SYSTEM", "admin", "new password")
 	assert := assert.New(t)
 	assert.Nil(err)
 }
@@ -1178,7 +1222,8 @@ func TestVirtualServerUpdateCredentialServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, VirtualServerApi{}.UpdateCredential("12345", "OPERATING_SYSTEM", "admin", "new password")
+				ctx := context.Background()
+				return nil, VirtualServerApi{}.UpdateCredential(ctx, "12345", "OPERATING_SYSTEM", "admin", "new password")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1195,7 +1240,8 @@ func TestVirtualServerUpdateCredentialServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, VirtualServerApi{}.UpdateCredential("12345", "OPERATING_SYSTEM", "admin", "new password")
+				ctx := context.Background()
+				return nil, VirtualServerApi{}.UpdateCredential(ctx, "12345", "OPERATING_SYSTEM", "admin", "new password")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1212,7 +1258,8 @@ func TestVirtualServerUpdateCredentialServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource '218030' was not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, VirtualServerApi{}.UpdateCredential("12345", "OPERATING_SYSTEM", "admin", "new password")
+				ctx := context.Background()
+				return nil, VirtualServerApi{}.UpdateCredential(ctx, "12345", "OPERATING_SYSTEM", "admin", "new password")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1229,7 +1276,8 @@ func TestVirtualServerUpdateCredentialServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, VirtualServerApi{}.UpdateCredential("12345", "OPERATING_SYSTEM", "admin", "new password")
+				ctx := context.Background()
+				return nil, VirtualServerApi{}.UpdateCredential(ctx, "12345", "OPERATING_SYSTEM", "admin", "new password")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1246,7 +1294,8 @@ func TestVirtualServerUpdateCredentialServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return nil, VirtualServerApi{}.UpdateCredential("12345", "OPERATING_SYSTEM", "admin", "new password")
+				ctx := context.Background()
+				return nil, VirtualServerApi{}.UpdateCredential(ctx, "12345", "OPERATING_SYSTEM", "admin", "new password")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1282,7 +1331,8 @@ func TestVirtualServerListCredentials(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := VirtualServerApi{}.ListCredentials("99944", "OPERATING_SYSTEM")
+	ctx := context.Background()
+	response, err := VirtualServerApi{}.ListCredentials(ctx, "99944", "OPERATING_SYSTEM")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 2)
@@ -1316,7 +1366,8 @@ func TestVirtualServerListCredentialsPaginate(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := VirtualServerApi{}.ListCredentials("99944", "OPERATING_SYSTEM", 1)
+	ctx := context.Background()
+	response, err := VirtualServerApi{}.ListCredentials(ctx, "99944", "OPERATING_SYSTEM", 1)
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Metadata.TotalCount, 11)
@@ -1339,7 +1390,8 @@ func TestVirtualServerListCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.ListCredentials("99944", "OPERATING_SYSTEM")
+				ctx := context.Background()
+				return VirtualServerApi{}.ListCredentials(ctx, "99944", "OPERATING_SYSTEM")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1356,7 +1408,8 @@ func TestVirtualServerListCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.ListCredentials("99944", "OPERATING_SYSTEM")
+				ctx := context.Background()
+				return VirtualServerApi{}.ListCredentials(ctx, "99944", "OPERATING_SYSTEM")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1373,7 +1426,8 @@ func TestVirtualServerListCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.ListCredentials("99944", "OPERATING_SYSTEM")
+				ctx := context.Background()
+				return VirtualServerApi{}.ListCredentials(ctx, "99944", "OPERATING_SYSTEM")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1390,7 +1444,8 @@ func TestVirtualServerListCredentialsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.ListCredentials("99944", "OPERATING_SYSTEM")
+				ctx := context.Background()
+				return VirtualServerApi{}.ListCredentials(ctx, "99944", "OPERATING_SYSTEM")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1414,7 +1469,8 @@ func TestVirtualServerGetCredential(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := VirtualServerApi{}.GetCredential("99944", "OPERATING_SYSTEM", "root")
+	ctx := context.Background()
+	response, err := VirtualServerApi{}.GetCredential(ctx, "99944", "OPERATING_SYSTEM", "root")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(response.Type, "OPERATING_SYSTEM")
@@ -1433,7 +1489,8 @@ func TestVirtualServerGetCredentialServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.GetCredential("99944", "OPERATING_SYSTEM", "root")
+				ctx := context.Background()
+				return VirtualServerApi{}.GetCredential(ctx, "99944", "OPERATING_SYSTEM", "root")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1450,7 +1507,8 @@ func TestVirtualServerGetCredentialServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.GetCredential("99944", "OPERATING_SYSTEM", "root")
+				ctx := context.Background()
+				return VirtualServerApi{}.GetCredential(ctx, "99944", "OPERATING_SYSTEM", "root")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1467,7 +1525,8 @@ func TestVirtualServerGetCredentialServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.GetCredential("99944", "OPERATING_SYSTEM", "root")
+				ctx := context.Background()
+				return VirtualServerApi{}.GetCredential(ctx, "99944", "OPERATING_SYSTEM", "root")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1484,7 +1543,8 @@ func TestVirtualServerGetCredentialServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.GetCredential("99944", "OPERATING_SYSTEM", "root")
+				ctx := context.Background()
+				return VirtualServerApi{}.GetCredential(ctx, "99944", "OPERATING_SYSTEM", "root")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1539,7 +1599,8 @@ func TestVirtualServerGetDataTrafficMetrics(t *testing.T) {
 	})
 	defer teardown()
 
-	Metric, err := VirtualServerApi{}.GetDataTrafficMetrics("12345", "DAY", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+	ctx := context.Background()
+	Metric, err := VirtualServerApi{}.GetDataTrafficMetrics(ctx, "12345", "DAY", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 	assert := assert.New(t)
 	assert.Nil(err)
 	assert.Equal(Metric.Metadata.Aggregation, "SUM")
@@ -1570,7 +1631,8 @@ func TestVirtualServerGetDataTrafficMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.GetDataTrafficMetrics("12345", "DAY", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+				ctx := context.Background()
+				return VirtualServerApi{}.GetDataTrafficMetrics(ctx, "12345", "DAY", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1587,7 +1649,8 @@ func TestVirtualServerGetDataTrafficMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.GetDataTrafficMetrics("12345", "DAY", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+				ctx := context.Background()
+				return VirtualServerApi{}.GetDataTrafficMetrics(ctx, "12345", "DAY", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1604,7 +1667,8 @@ func TestVirtualServerGetDataTrafficMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "404", "errorMessage": "Resource '218030' was not found"}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.GetDataTrafficMetrics("12345", "DAY", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+				ctx := context.Background()
+				return VirtualServerApi{}.GetDataTrafficMetrics(ctx, "12345", "DAY", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1621,7 +1685,8 @@ func TestVirtualServerGetDataTrafficMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.GetDataTrafficMetrics("12345", "DAY", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+				ctx := context.Background()
+				return VirtualServerApi{}.GetDataTrafficMetrics(ctx, "12345", "DAY", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1638,7 +1703,8 @@ func TestVirtualServerGetDataTrafficMetricsServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.GetDataTrafficMetrics("12345", "DAY", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
+				ctx := context.Background()
+				return VirtualServerApi{}.GetDataTrafficMetrics(ctx, "12345", "DAY", "SUM", "2016-10-20T09:00:00Z", "2016-10-20T11:00:00Z")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1674,7 +1740,8 @@ func TestVirtualServerListTemplates(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := VirtualServerApi{}.ListTemplates("12345")
+	ctx := context.Background()
+	response, err := VirtualServerApi{}.ListTemplates(ctx, "12345")
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -1709,7 +1776,8 @@ func TestVirtualServerListTemplatesPaginate(t *testing.T) {
 	})
 	defer teardown()
 
-	response, err := VirtualServerApi{}.ListTemplates("12345", 1)
+	ctx := context.Background()
+	response, err := VirtualServerApi{}.ListTemplates(ctx, "12345", 1)
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -1733,7 +1801,8 @@ func TestVirtualServerListTemplatesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "401", "errorMessage": "You are not authorized to view this resource."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.ListTemplates("12345")
+				ctx := context.Background()
+				return VirtualServerApi{}.ListTemplates(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1750,7 +1819,8 @@ func TestVirtualServerListTemplatesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "ACCESS_DENIED", "errorMessage": "The access token is expired or invalid."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.ListTemplates("12345")
+				ctx := context.Background()
+				return VirtualServerApi{}.ListTemplates(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1767,7 +1837,8 @@ func TestVirtualServerListTemplatesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "SERVER_ERROR", "errorMessage": "The server encountered an unexpected condition that prevented it from fulfilling the request."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.ListTemplates("12345")
+				ctx := context.Background()
+				return VirtualServerApi{}.ListTemplates(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",
@@ -1784,7 +1855,8 @@ func TestVirtualServerListTemplatesServerErrors(t *testing.T) {
 				fmt.Fprintf(w, `{"correlationId":"289346a1-3eaf-4da4-b707-62ef12eb08be", "errorCode": "TEMPORARILY_UNAVAILABLE", "errorMessage": "The server is currently unable to handle the request due to a temporary overloading or maintenance of the server."}`)
 			},
 			FunctionCall: func() (interface{}, error) {
-				return VirtualServerApi{}.ListTemplates("12345")
+				ctx := context.Background()
+				return VirtualServerApi{}.ListTemplates(ctx, "12345")
 			},
 			ExpectedError: ApiError{
 				CorrelationId: "289346a1-3eaf-4da4-b707-62ef12eb08be",


### PR DESCRIPTION
This is quite a standard to provide control over the cancellation and timeouts of the requests.