### PR TITLE
Move query to doRequest function parameter

### DIFF
--- a/abuse.go
+++ b/abuse.go
@@ -91,9 +91,10 @@ func (aba AbuseApi) List(ctx context.Context, args ...interface{}) (*AbuseReport
 		v.Add("limit", fmt.Sprint(args[2]))
 	}
 
-	path := aba.getPath("/reports?" + v.Encode())
+	path := aba.getPath("/reports")
+	query := v.Encode()
 	result := &AbuseReports{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -102,7 +103,7 @@ func (aba AbuseApi) List(ctx context.Context, args ...interface{}) (*AbuseReport
 func (aba AbuseApi) Get(ctx context.Context, abuseReportId string) (*AbuseReport, error) {
 	path := aba.getPath("/reports/" + abuseReportId)
 	result := &AbuseReport{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -117,9 +118,10 @@ func (aba AbuseApi) ListMessages(ctx context.Context, abuseReportId string, args
 		v.Add("limit", fmt.Sprint(args[1]))
 	}
 
-	path := aba.getPath("/reports/" + abuseReportId + "/messages" + v.Encode())
+	path := aba.getPath("/reports/" + abuseReportId + "/messages")
+	query := v.Encode()
 	result := &AbuseMessages{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -129,7 +131,7 @@ func (aba AbuseApi) CreateMessage(ctx context.Context, abuseReportId string, bod
 	var result []string
 	payload := map[string]string{body: body}
 	path := aba.getPath("/reports/" + abuseReportId + "/messages")
-	if err := doRequest(ctx, http.MethodPost, path, &result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", &result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -138,7 +140,7 @@ func (aba AbuseApi) CreateMessage(ctx context.Context, abuseReportId string, bod
 func (aba AbuseApi) ListResolutionOptions(ctx context.Context, abuseReportId string) (*AbuseResolutions, error) {
 	path := aba.getPath("/reports/" + abuseReportId + "/resolutions")
 	result := &AbuseResolutions{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -147,7 +149,7 @@ func (aba AbuseApi) ListResolutionOptions(ctx context.Context, abuseReportId str
 func (aba AbuseApi) Resolve(ctx context.Context, abuseReportId string, resolutions []string) error {
 	payload := map[string][]string{"resolutions": resolutions}
 	path := aba.getPath("/reports/" + abuseReportId + "/resolve")
-	return doRequest(ctx, http.MethodPost, path, nil, payload)
+	return doRequest(ctx, http.MethodPost, path, "", nil, payload)
 }
 
 // TODO

--- a/customer_account.go
+++ b/customer_account.go
@@ -60,7 +60,7 @@ func (cai CustomerAccountApi) getPath(endpoint string) string {
 func (cai CustomerAccountApi) Get(ctx context.Context) (*CustomerAccount, error) {
 	path := cai.getPath("/details")
 	result := &CustomerAccount{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -69,7 +69,7 @@ func (cai CustomerAccountApi) Get(ctx context.Context) (*CustomerAccount, error)
 func (cai CustomerAccountApi) Update(ctx context.Context, ad CustomerAccountAddress) error {
 	path := cai.getPath("/details")
 	payload := map[string]CustomerAccountAddress{"address": ad}
-	return doRequest(ctx, http.MethodPut, path, nil, payload)
+	return doRequest(ctx, http.MethodPut, path, "", nil, payload)
 }
 
 func (cai CustomerAccountApi) ListContacts(ctx context.Context, args ...interface{}) (*CustomerAccountContacts, error) {
@@ -89,9 +89,10 @@ func (cai CustomerAccountApi) ListContacts(ctx context.Context, args ...interfac
 		v.Add("primaryRoles", strings.Join(primaryRoles, ","))
 	}
 
-	path := cai.getPath("/contacts?" + v.Encode())
+	path := cai.getPath("/contacts")
+	query := v.Encode()
 	result := &CustomerAccountContacts{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -100,7 +101,7 @@ func (cai CustomerAccountApi) ListContacts(ctx context.Context, args ...interfac
 func (cai CustomerAccountApi) CreateContact(ctx context.Context, newContact CustomerAccountContact) (*CustomerAccountContact, error) {
 	path := cai.getPath("/contacts")
 	result := &CustomerAccountContact{}
-	if err := doRequest(ctx, http.MethodPost, path, result, newContact); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result, newContact); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -108,13 +109,13 @@ func (cai CustomerAccountApi) CreateContact(ctx context.Context, newContact Cust
 
 func (cai CustomerAccountApi) DeleteContact(ctx context.Context, contactId string) error {
 	path := cai.getPath("/contacts/" + contactId)
-	return doRequest(ctx, http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (cai CustomerAccountApi) GetContact(ctx context.Context, contactId string) (*CustomerAccountContact, error) {
 	path := cai.getPath("/contacts/" + contactId)
 	result := &CustomerAccountContact{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -132,11 +133,11 @@ func (cai CustomerAccountApi) UpdateContact(ctx context.Context, contactId strin
 	}
 
 	path := cai.getPath("/contacts" + contactId)
-	return doRequest(ctx, http.MethodPut, path, nil, payload)
+	return doRequest(ctx, http.MethodPut, path, "", nil, payload)
 }
 
 func (cai CustomerAccountApi) AssignPrimaryRolesToContact(ctx context.Context, contactId string, roles []string) error {
 	payload := map[string][]string{"roles": roles}
 	path := cai.getPath("/contacts" + contactId)
-	return doRequest(ctx, http.MethodPost, path, nil, payload)
+	return doRequest(ctx, http.MethodPost, path, "", nil, payload)
 }

--- a/dedicated_network_equipment.go
+++ b/dedicated_network_equipment.go
@@ -71,9 +71,10 @@ func (dnea DedicatedNetworkEquipmentApi) List(ctx context.Context, args ...inter
 		v.Add("privateNetworkEnabled", fmt.Sprint(args[7]))
 	}
 
-	path := dnea.getPath("/networkEquipments?" + v.Encode())
+	path := dnea.getPath("/networkEquipments")
+	query := v.Encode()
 	result := &DedicatedNetworkEquipments{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -82,7 +83,7 @@ func (dnea DedicatedNetworkEquipmentApi) List(ctx context.Context, args ...inter
 func (dnea DedicatedNetworkEquipmentApi) Get(ctx context.Context, networkEquipmentId string) (*DedicatedNetworkEquipment, error) {
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId)
 	result := &DedicatedNetworkEquipment{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -91,7 +92,7 @@ func (dnea DedicatedNetworkEquipmentApi) Get(ctx context.Context, networkEquipme
 func (dnea DedicatedNetworkEquipmentApi) Update(ctx context.Context, networkEquipmentId, reference string) error {
 	payload := map[string]string{"reference": reference}
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId)
-	return doRequest(ctx, http.MethodPut, path, nil, payload)
+	return doRequest(ctx, http.MethodPut, path, "", nil, payload)
 }
 
 func (dnea DedicatedNetworkEquipmentApi) ListIps(ctx context.Context, networkEquipmentId string, args ...interface{}) (*Ips, error) {
@@ -115,9 +116,10 @@ func (dnea DedicatedNetworkEquipmentApi) ListIps(ctx context.Context, networkEqu
 		v.Add("ips", fmt.Sprint(args[5]))
 	}
 
-	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/ips" + v.Encode())
+	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/ips")
+	query := v.Encode()
 	result := &Ips{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -126,7 +128,7 @@ func (dnea DedicatedNetworkEquipmentApi) ListIps(ctx context.Context, networkEqu
 func (dnea DedicatedNetworkEquipmentApi) GetIp(ctx context.Context, networkEquipmentId, ip string) (*Ip, error) {
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/ips/" + ip)
 	result := &Ip{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -135,7 +137,7 @@ func (dnea DedicatedNetworkEquipmentApi) GetIp(ctx context.Context, networkEquip
 func (dnea DedicatedNetworkEquipmentApi) UpdateIp(ctx context.Context, networkEquipmentId, ip string, payload map[string]string) (*Ip, error) {
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/ips/" + ip)
 	result := &Ip{}
-	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -144,7 +146,7 @@ func (dnea DedicatedNetworkEquipmentApi) UpdateIp(ctx context.Context, networkEq
 func (dnea DedicatedNetworkEquipmentApi) NullRouteAnIp(ctx context.Context, networkEquipmentId, ip string) (*Ip, error) {
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/ips/" + ip + "/null")
 	result := &Ip{}
-	if err := doRequest(ctx, http.MethodPost, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -153,7 +155,7 @@ func (dnea DedicatedNetworkEquipmentApi) NullRouteAnIp(ctx context.Context, netw
 func (dnea DedicatedNetworkEquipmentApi) RemoveNullRouteAnIp(ctx context.Context, networkEquipmentId, ip string) (*Ip, error) {
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/ips/" + ip + "/unnull")
 	result := &Ip{}
-	if err := doRequest(ctx, http.MethodPost, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -168,9 +170,10 @@ func (dnea DedicatedNetworkEquipmentApi) ListNullRoutes(ctx context.Context, net
 		v.Add("limit", fmt.Sprint(args[1]))
 	}
 
-	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/nullRouteHistory?" + v.Encode())
+	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/nullRouteHistory")
+	query := v.Encode()
 	result := &NullRoutes{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -186,8 +189,9 @@ func (dnea DedicatedNetworkEquipmentApi) ListCredentials(ctx context.Context, ne
 	}
 
 	result := &Credentials{}
-	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/credentials?" + v.Encode())
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/credentials")
+	query := v.Encode()
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -200,7 +204,7 @@ func (dnea DedicatedNetworkEquipmentApi) CreateCredential(ctx context.Context, n
 	payload["username"] = username
 	payload["password"] = password
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/credentials")
-	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -216,8 +220,9 @@ func (dnea DedicatedNetworkEquipmentApi) ListCredentialsByType(ctx context.Conte
 	}
 
 	result := &Credentials{}
-	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/credentials/" + credentialType + "?" + v.Encode())
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/credentials/" + credentialType)
+	query := v.Encode()
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -226,7 +231,7 @@ func (dnea DedicatedNetworkEquipmentApi) ListCredentialsByType(ctx context.Conte
 func (dnea DedicatedNetworkEquipmentApi) GetCredential(ctx context.Context, networkEquipmentId, credentialType, username string) (*Credential, error) {
 	result := &Credential{}
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/credentials/" + credentialType + "/" + username)
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -234,14 +239,14 @@ func (dnea DedicatedNetworkEquipmentApi) GetCredential(ctx context.Context, netw
 
 func (dnea DedicatedNetworkEquipmentApi) DeleteCredential(ctx context.Context, networkEquipmentId, credentialType, username string) error {
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/credentials/" + credentialType + "/" + username)
-	return doRequest(ctx, http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (dnea DedicatedNetworkEquipmentApi) UpdateCredential(ctx context.Context, networkEquipmentId, credentialType, username, password string) (*Credential, error) {
 	result := &Credential{}
 	payload := map[string]string{"password": password}
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/credentials/" + credentialType + "/" + username)
-	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -249,13 +254,13 @@ func (dnea DedicatedNetworkEquipmentApi) UpdateCredential(ctx context.Context, n
 
 func (dnea DedicatedNetworkEquipmentApi) PowerCycleServer(ctx context.Context, networkEquipmentId string) error {
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/powerCycle")
-	return doRequest(ctx, http.MethodPost, path)
+	return doRequest(ctx, http.MethodPost, path, "")
 }
 
 func (dnea DedicatedNetworkEquipmentApi) GetPowerStatus(ctx context.Context, networkEquipmentId string) (*PowerStatus, error) {
 	result := &PowerStatus{}
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/powerInfo")
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -263,10 +268,10 @@ func (dnea DedicatedNetworkEquipmentApi) GetPowerStatus(ctx context.Context, net
 
 func (dnea DedicatedNetworkEquipmentApi) PowerOffServer(ctx context.Context, networkEquipmentId string) error {
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/powerOff")
-	return doRequest(ctx, http.MethodPost, path)
+	return doRequest(ctx, http.MethodPost, path, "")
 }
 
 func (dnea DedicatedNetworkEquipmentApi) PowerOnServer(ctx context.Context, networkEquipmentId string) error {
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/powerOn")
-	return doRequest(ctx, http.MethodPost, path)
+	return doRequest(ctx, http.MethodPost, path, "")
 }

--- a/dedicated_rack.go
+++ b/dedicated_rack.go
@@ -51,9 +51,10 @@ func (dra DedicatedRackApi) List(ctx context.Context, args ...interface{}) (*Ded
 		v.Add("privateNetworkEnabled", fmt.Sprint(args[3]))
 	}
 
-	path := dra.getPath("/privateRacks?" + v.Encode())
+	path := dra.getPath("/privateRacks")
+	query := v.Encode()
 	result := &DedicatedRacks{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -62,7 +63,7 @@ func (dra DedicatedRackApi) List(ctx context.Context, args ...interface{}) (*Ded
 func (dra DedicatedRackApi) Get(ctx context.Context, privateRackId string) (*DedicatedRack, error) {
 	path := dra.getPath("/privateRacks/" + privateRackId)
 	result := &DedicatedRack{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -71,7 +72,7 @@ func (dra DedicatedRackApi) Get(ctx context.Context, privateRackId string) (*Ded
 func (dra DedicatedRackApi) Update(ctx context.Context, privateRackId, reference string) error {
 	payload := map[string]string{"reference": reference}
 	path := dra.getPath("/privateRacks/" + privateRackId)
-	return doRequest(ctx, http.MethodPut, path, nil, payload)
+	return doRequest(ctx, http.MethodPut, path, "", nil, payload)
 }
 
 func (dra DedicatedRackApi) ListNullRoutes(ctx context.Context, privateRackId string, args ...interface{}) (*NullRoutes, error) {
@@ -83,9 +84,10 @@ func (dra DedicatedRackApi) ListNullRoutes(ctx context.Context, privateRackId st
 		v.Add("limit", fmt.Sprint(args[1]))
 	}
 
-	path := dra.getPath("/privateRacks/" + privateRackId + "/nullRouteHistory?" + v.Encode())
+	path := dra.getPath("/privateRacks/" + privateRackId + "/nullRouteHistory")
+	query := v.Encode()
 	result := &NullRoutes{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -112,9 +114,10 @@ func (dra DedicatedRackApi) ListIps(ctx context.Context, privateRackId string, a
 		v.Add("ips", fmt.Sprint(args[5]))
 	}
 
-	path := dra.getPath("/privateRacks/" + privateRackId + "/ips" + v.Encode())
+	path := dra.getPath("/privateRacks/" + privateRackId + "/ips")
+	query := v.Encode()
 	result := &Ips{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -123,7 +126,7 @@ func (dra DedicatedRackApi) ListIps(ctx context.Context, privateRackId string, a
 func (dra DedicatedRackApi) GetIp(ctx context.Context, privateRackId, ip string) (*Ip, error) {
 	path := dra.getPath("/privateRacks/" + privateRackId + "/ips/" + ip)
 	result := &Ip{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -132,7 +135,7 @@ func (dra DedicatedRackApi) GetIp(ctx context.Context, privateRackId, ip string)
 func (dra DedicatedRackApi) UpdateIp(ctx context.Context, privateRackId, ip string, payload map[string]string) (*Ip, error) {
 	path := dra.getPath("/privateRacks/" + privateRackId + "/ips/" + ip)
 	result := &Ip{}
-	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -141,7 +144,7 @@ func (dra DedicatedRackApi) UpdateIp(ctx context.Context, privateRackId, ip stri
 func (dra DedicatedRackApi) NullRouteAnIp(ctx context.Context, privateRackId, ip string) (*Ip, error) {
 	path := dra.getPath("/privateRacks/" + privateRackId + "/ips/" + ip + "/null")
 	result := &Ip{}
-	if err := doRequest(ctx, http.MethodPost, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -150,7 +153,7 @@ func (dra DedicatedRackApi) NullRouteAnIp(ctx context.Context, privateRackId, ip
 func (dra DedicatedRackApi) RemoveNullRouteAnIp(ctx context.Context, privateRackId, ip string) (*Ip, error) {
 	path := dra.getPath("/privateRacks/" + privateRackId + "/ips/" + ip + "/unnull")
 	result := &Ip{}
-	if err := doRequest(ctx, http.MethodPost, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -166,8 +169,9 @@ func (dra DedicatedRackApi) ListCredentials(ctx context.Context, privateRackId s
 	}
 
 	result := &Credentials{}
-	path := dra.getPath("/privateRacks/" + privateRackId + "/credentials?" + v.Encode())
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	query := v.Encode()
+	path := dra.getPath("/privateRacks/" + privateRackId + "/credentials")
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -180,7 +184,7 @@ func (dra DedicatedRackApi) CreateCredential(ctx context.Context, privateRackId,
 	payload["username"] = username
 	payload["password"] = password
 	path := dra.getPath("/privateRacks/" + privateRackId + "/credentials")
-	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -196,8 +200,9 @@ func (dra DedicatedRackApi) ListCredentialsByType(ctx context.Context, privateRa
 	}
 
 	result := &Credentials{}
-	path := dra.getPath("/privateRacks/" + privateRackId + "/credentials/" + credentialType + "?" + v.Encode())
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	path := dra.getPath("/privateRacks/" + privateRackId + "/credentials/" + credentialType)
+	query := v.Encode()
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -206,7 +211,7 @@ func (dra DedicatedRackApi) ListCredentialsByType(ctx context.Context, privateRa
 func (dra DedicatedRackApi) GetCredential(ctx context.Context, privateRackId, credentialType, username string) (*Credential, error) {
 	result := &Credential{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/credentials/" + credentialType + "/" + username)
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -214,14 +219,14 @@ func (dra DedicatedRackApi) GetCredential(ctx context.Context, privateRackId, cr
 
 func (dra DedicatedRackApi) DeleteCredential(ctx context.Context, privateRackId, credentialType, username string) error {
 	path := dra.getPath("/privateRacks/" + privateRackId + "/credentials/" + credentialType + "/" + username)
-	return doRequest(ctx, http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (dra DedicatedRackApi) UpdateCredential(ctx context.Context, privateRackId, credentialType, username, password string) (*Credential, error) {
 	result := &Credential{}
 	payload := map[string]string{"password": password}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/credentials/" + credentialType + "/" + username)
-	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -242,9 +247,10 @@ func (dra DedicatedRackApi) GetDataTrafficMetrics(ctx context.Context, privateRa
 		v.Add("to", fmt.Sprint(args[3]))
 	}
 
-	path := dra.getPath("/privateRacks/" + privateRackId + "/metrics/datatraffic?" + v.Encode())
+	path := dra.getPath("/privateRacks/" + privateRackId + "/metrics/datatraffic")
+	query := v.Encode()
 	result := &DataTrafficMetricsV1{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -265,9 +271,10 @@ func (dra DedicatedRackApi) GetBandWidthMetrics(ctx context.Context, privateRack
 		v.Add("to", fmt.Sprint(args[3]))
 	}
 
-	path := dra.getPath("/privateRacks/" + privateRackId + "/metrics/bandwidth?" + v.Encode())
+	path := dra.getPath("/privateRacks/" + privateRackId + "/metrics/bandwidth")
+	query := v.Encode()
 	result := &BandWidthMetrics{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -276,7 +283,7 @@ func (dra DedicatedRackApi) GetBandWidthMetrics(ctx context.Context, privateRack
 func (dra DedicatedRackApi) GetDdosNotificationSetting(ctx context.Context, privateRackId string) (*DdosNotificationSetting, error) {
 	result := &DdosNotificationSetting{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/ddos")
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -284,7 +291,7 @@ func (dra DedicatedRackApi) GetDdosNotificationSetting(ctx context.Context, priv
 
 func (dra DedicatedRackApi) UpdateDdosNotificationSetting(ctx context.Context, privateRackId string, payload map[string]string) error {
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/ddos")
-	if err := doRequest(ctx, http.MethodPut, path, nil, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, "", nil, payload); err != nil {
 		return err
 	}
 	return nil
@@ -300,8 +307,9 @@ func (dra DedicatedRackApi) ListBandWidthNotificationSettings(ctx context.Contex
 	}
 
 	result := &BandWidthNotificationSettings{}
-	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/bandwidth?" + v.Encode())
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	query := v.Encode()
+	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/bandwidth")
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -315,7 +323,7 @@ func (dra DedicatedRackApi) CreateBandWidthNotificationSetting(ctx context.Conte
 	}
 	result := &NotificationSetting{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/bandwidth")
-	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -323,13 +331,13 @@ func (dra DedicatedRackApi) CreateBandWidthNotificationSetting(ctx context.Conte
 
 func (dra DedicatedRackApi) DeleteBandWidthNotificationSetting(ctx context.Context, privateRackId, notificationId string) error {
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/bandwidth/" + notificationId)
-	return doRequest(ctx, http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (dra DedicatedRackApi) GetBandWidthNotificationSetting(ctx context.Context, privateRackId, notificationId string) (*NotificationSetting, error) {
 	result := &NotificationSetting{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/bandwidth/" + notificationId)
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -338,7 +346,7 @@ func (dra DedicatedRackApi) GetBandWidthNotificationSetting(ctx context.Context,
 func (dra DedicatedRackApi) UpdateBandWidthNotificationSetting(ctx context.Context, privateRackId, notificationSettingId string, payload map[string]string) (*NotificationSetting, error) {
 	result := &NotificationSetting{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/bandwidth/" + notificationSettingId)
-	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -354,8 +362,9 @@ func (dra DedicatedRackApi) ListDataTrafficNotificationSettings(ctx context.Cont
 	}
 
 	result := &DataTrafficNotificationSettings{}
-	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/datatraffic?" + v.Encode())
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/datatraffic")
+	query := v.Encode()
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -369,7 +378,7 @@ func (dra DedicatedRackApi) CreateDataTrafficNotificationSetting(ctx context.Con
 	}
 	result := &NotificationSetting{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/datatraffic")
-	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -377,13 +386,13 @@ func (dra DedicatedRackApi) CreateDataTrafficNotificationSetting(ctx context.Con
 
 func (dra DedicatedRackApi) DeleteDataTrafficNotificationSetting(ctx context.Context, privateRackId, notificationId string) error {
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/datatraffic/" + notificationId)
-	return doRequest(ctx, http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (dra DedicatedRackApi) GetDataTrafficNotificationSetting(ctx context.Context, privateRackId, notificationId string) (*NotificationSetting, error) {
 	result := &NotificationSetting{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/datatraffic/" + notificationId)
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -392,7 +401,7 @@ func (dra DedicatedRackApi) GetDataTrafficNotificationSetting(ctx context.Contex
 func (dra DedicatedRackApi) UpdateDataTrafficNotificationSetting(ctx context.Context, privateRackId, notificationSettingId string, payload map[string]string) (*NotificationSetting, error) {
 	result := &NotificationSetting{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/datatraffic/" + notificationSettingId)
-	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil

--- a/dedicated_server.go
+++ b/dedicated_server.go
@@ -434,9 +434,10 @@ func (dsa DedicatedServerApi) getPath(endpoint string) string {
 }
 
 func (dsa DedicatedServerApi) List(ctx context.Context, opts DedicatedServerListOptions) (*DedicatedServers, error) {
-	path := dsa.getPath("/servers?" + options.Encode(opts))
+	path := dsa.getPath("/servers")
+	query := options.Encode(opts)
 	result := &DedicatedServers{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -445,7 +446,7 @@ func (dsa DedicatedServerApi) List(ctx context.Context, opts DedicatedServerList
 func (dsa DedicatedServerApi) Get(ctx context.Context, serverId string) (*DedicatedServer, error) {
 	path := dsa.getPath("/servers/" + serverId)
 	result := &DedicatedServer{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -453,13 +454,13 @@ func (dsa DedicatedServerApi) Get(ctx context.Context, serverId string) (*Dedica
 
 func (dsa DedicatedServerApi) Update(ctx context.Context, serverId string, payload map[string]interface{}) error {
 	path := dsa.getPath("/servers/" + serverId)
-	return doRequest(ctx, http.MethodPut, path, nil, payload)
+	return doRequest(ctx, http.MethodPut, path, "", nil, payload)
 }
 
 func (dsa DedicatedServerApi) GetHardwareInformation(ctx context.Context, serverId string) (*DedicatedServerHardware, error) {
 	path := dsa.getPath("/servers/" + serverId + "/hardwareInfo")
 	result := &DedicatedServerHardware{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -486,9 +487,10 @@ func (dsa DedicatedServerApi) ListIps(ctx context.Context, serverId string, args
 		v.Add("ips", fmt.Sprint(args[5]))
 	}
 
-	path := dsa.getPath("/servers/" + serverId + "/ips" + v.Encode())
+	path := dsa.getPath("/servers/" + serverId + "/ips")
+	query := v.Encode()
 	result := &Ips{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -497,7 +499,7 @@ func (dsa DedicatedServerApi) ListIps(ctx context.Context, serverId string, args
 func (dsa DedicatedServerApi) GetIp(ctx context.Context, serverId, ip string) (*Ip, error) {
 	path := dsa.getPath("/servers/" + serverId + "/ips/" + ip)
 	result := &Ip{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -506,7 +508,7 @@ func (dsa DedicatedServerApi) GetIp(ctx context.Context, serverId, ip string) (*
 func (dsa DedicatedServerApi) UpdateIp(ctx context.Context, serverId, ip string, payload map[string]string) (*Ip, error) {
 	path := dsa.getPath("/servers/" + serverId + "/ips/" + ip)
 	result := &Ip{}
-	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -515,7 +517,7 @@ func (dsa DedicatedServerApi) UpdateIp(ctx context.Context, serverId, ip string,
 func (dsa DedicatedServerApi) NullRouteAnIp(ctx context.Context, serverId, ip string) (*Ip, error) {
 	path := dsa.getPath("/servers/" + serverId + "/ips/" + ip + "/null")
 	result := &Ip{}
-	if err := doRequest(ctx, http.MethodPost, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -524,7 +526,7 @@ func (dsa DedicatedServerApi) NullRouteAnIp(ctx context.Context, serverId, ip st
 func (dsa DedicatedServerApi) RemoveNullRouteAnIp(ctx context.Context, serverId, ip string) (*Ip, error) {
 	path := dsa.getPath("/servers/" + serverId + "/ips/" + ip + "/unnull")
 	result := &Ip{}
-	if err := doRequest(ctx, http.MethodPost, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -539,9 +541,10 @@ func (dsa DedicatedServerApi) ListNullRoutes(ctx context.Context, serverId strin
 		v.Add("limit", fmt.Sprint(args[1]))
 	}
 
-	path := dsa.getPath("/servers/" + serverId + "/nullRouteHistory?" + v.Encode())
+	path := dsa.getPath("/servers/" + serverId + "/nullRouteHistory")
+	query := v.Encode()
 	result := &NullRoutes{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -558,7 +561,7 @@ func (dsa DedicatedServerApi) ListNetworkInterfaces(ctx context.Context, serverI
 
 	path := dsa.getPath("/servers/" + serverId + "/networkInterfaces")
 	result := &DedicatedServerNetworkInterfaces{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -566,18 +569,18 @@ func (dsa DedicatedServerApi) ListNetworkInterfaces(ctx context.Context, serverI
 
 func (dsa DedicatedServerApi) CloseAllNetworkInterfaces(ctx context.Context, serverId string) error {
 	path := dsa.getPath("/servers/" + serverId + "/networkInterfaces/close")
-	return doRequest(ctx, http.MethodPost, path)
+	return doRequest(ctx, http.MethodPost, path, "")
 }
 
 func (dsa DedicatedServerApi) OpenAllNetworkInterfaces(ctx context.Context, serverId string) error {
 	path := dsa.getPath("/servers/" + serverId + "/networkInterfaces/open")
-	return doRequest(ctx, http.MethodPost, path)
+	return doRequest(ctx, http.MethodPost, path, "")
 }
 
 func (dsa DedicatedServerApi) GetNetworkInterface(ctx context.Context, serverId, networkType string) (*DedicatedServerNetworkInterface, error) {
 	path := dsa.getPath("/servers/" + serverId + "/networkInterfaces/" + networkType)
 	result := &DedicatedServerNetworkInterface{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -585,28 +588,28 @@ func (dsa DedicatedServerApi) GetNetworkInterface(ctx context.Context, serverId,
 
 func (dsa DedicatedServerApi) CloseNetworkInterface(ctx context.Context, serverId, networkType string) error {
 	path := dsa.getPath("/servers/" + serverId + "/networkInterfaces/" + networkType + "/close")
-	return doRequest(ctx, http.MethodPost, path)
+	return doRequest(ctx, http.MethodPost, path, "")
 }
 
 func (dsa DedicatedServerApi) OpenNetworkInterface(ctx context.Context, serverId, networkType string) error {
 	path := dsa.getPath("/servers/" + serverId + "/networkInterfaces/" + networkType + "/open")
-	return doRequest(ctx, http.MethodPost, path)
+	return doRequest(ctx, http.MethodPost, path, "")
 }
 
 func (dsa DedicatedServerApi) DeleteServerFromPrivateNetwork(ctx context.Context, serverId, privateNetworkId string) error {
 	path := dsa.getPath("/servers/" + serverId + "/privateNetworks/" + privateNetworkId)
-	return doRequest(ctx, http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (dsa DedicatedServerApi) AddServerToPrivateNetwork(ctx context.Context, serverId, privateNetworkId string, linkSpeed int) error {
 	payload := map[string]int{"linkSpeed": linkSpeed}
 	path := dsa.getPath("/servers/" + serverId + "/privateNetworks/" + privateNetworkId)
-	return doRequest(ctx, http.MethodPut, path, nil, payload)
+	return doRequest(ctx, http.MethodPut, path, "", nil, payload)
 }
 
 func (dsa DedicatedServerApi) DeleteDhcpReservation(ctx context.Context, serverId string) error {
 	path := dsa.getPath("/servers/" + serverId + "/leases")
-	return doRequest(ctx, http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (dsa DedicatedServerApi) ListDhcpReservation(ctx context.Context, serverId string, args ...interface{}) (*DedicatedServerDhcpReservations, error) {
@@ -617,9 +620,10 @@ func (dsa DedicatedServerApi) ListDhcpReservation(ctx context.Context, serverId 
 	if len(args) >= 2 {
 		v.Add("limit", fmt.Sprint(args[1]))
 	}
-	path := dsa.getPath("/servers/" + serverId + "/leases" + v.Encode())
+	path := dsa.getPath("/servers/" + serverId + "/leases")
+	query := v.Encode()
 	result := &DedicatedServerDhcpReservations{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -627,13 +631,13 @@ func (dsa DedicatedServerApi) ListDhcpReservation(ctx context.Context, serverId 
 
 func (dsa DedicatedServerApi) CreateDhcpReservation(ctx context.Context, serverId string, payload map[string]string) error {
 	path := dsa.getPath("/servers/" + serverId + "/leases")
-	return doRequest(ctx, http.MethodPost, path, nil, payload)
+	return doRequest(ctx, http.MethodPost, path, "", nil, payload)
 }
 
 func (dsa DedicatedServerApi) CancelActiveJob(ctx context.Context, serverId string) (*DedicatedServerJob, error) {
 	result := &DedicatedServerJob{}
 	path := dsa.getPath("/servers/" + serverId + "/cancelActiveJob")
-	if err := doRequest(ctx, http.MethodPost, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -642,7 +646,7 @@ func (dsa DedicatedServerApi) CancelActiveJob(ctx context.Context, serverId stri
 func (dsa DedicatedServerApi) ExpireActiveJob(ctx context.Context, serverId string) (*DedicatedServerJob, error) {
 	result := &DedicatedServerJob{}
 	path := dsa.getPath("/servers/" + serverId + "/expireActiveJob")
-	if err := doRequest(ctx, http.MethodPost, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -651,7 +655,7 @@ func (dsa DedicatedServerApi) ExpireActiveJob(ctx context.Context, serverId stri
 func (dsa DedicatedServerApi) LaunchHardwareScan(ctx context.Context, serverId string, payload map[string]interface{}) (*DedicatedServerJob, error) {
 	result := &DedicatedServerJob{}
 	path := dsa.getPath("/servers/" + serverId + "/hardwareScan")
-	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -660,7 +664,7 @@ func (dsa DedicatedServerApi) LaunchHardwareScan(ctx context.Context, serverId s
 func (dsa DedicatedServerApi) LaunchInstallation(ctx context.Context, serverId string, payload map[string]interface{}) (*DedicatedServerJob, error) {
 	result := &DedicatedServerJob{}
 	path := dsa.getPath("/servers/" + serverId + "/install")
-	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -669,7 +673,7 @@ func (dsa DedicatedServerApi) LaunchInstallation(ctx context.Context, serverId s
 func (dsa DedicatedServerApi) LaunchIpmiRest(ctx context.Context, serverId string, payload map[string]interface{}) (*DedicatedServerJob, error) {
 	result := &DedicatedServerJob{}
 	path := dsa.getPath("/servers/" + serverId + "/ipmiRest")
-	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -694,8 +698,9 @@ func (dsa DedicatedServerApi) ListJobs(ctx context.Context, serverId string, arg
 	}
 
 	result := &DedicatedServerJobs{}
-	path := dsa.getPath("/servers/" + serverId + "/jobs?" + v.Encode())
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	path := dsa.getPath("/servers/" + serverId + "/jobs")
+	query := v.Encode()
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -704,7 +709,7 @@ func (dsa DedicatedServerApi) ListJobs(ctx context.Context, serverId string, arg
 func (dsa DedicatedServerApi) GetJob(ctx context.Context, serverId, jobId string) (*DedicatedServerJob, error) {
 	result := &DedicatedServerJob{}
 	path := dsa.getPath("/servers/" + serverId + "/jobs/" + jobId)
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -713,7 +718,7 @@ func (dsa DedicatedServerApi) GetJob(ctx context.Context, serverId, jobId string
 func (dsa DedicatedServerApi) LaunchRescueMode(ctx context.Context, serverId string, payload map[string]interface{}) (*DedicatedServerJob, error) {
 	result := &DedicatedServerJob{}
 	path := dsa.getPath("/servers/" + serverId + "/rescueMode")
-	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -729,8 +734,9 @@ func (dsa DedicatedServerApi) ListCredentials(ctx context.Context, serverId stri
 	}
 
 	result := &Credentials{}
-	path := dsa.getPath("/servers/" + serverId + "/credentials?" + v.Encode())
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	path := dsa.getPath("/servers/" + serverId + "/credentials")
+	query := v.Encode()
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -743,7 +749,7 @@ func (dsa DedicatedServerApi) CreateCredential(ctx context.Context, serverId, cr
 	payload["username"] = username
 	payload["password"] = password
 	path := dsa.getPath("/servers/" + serverId + "/credentials")
-	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -759,8 +765,9 @@ func (dsa DedicatedServerApi) ListCredentialsByType(ctx context.Context, serverI
 	}
 
 	result := &Credentials{}
-	path := dsa.getPath("/servers/" + serverId + "/credentials/" + credentialType + "?" + v.Encode())
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	path := dsa.getPath("/servers/" + serverId + "/credentials/" + credentialType)
+	query := v.Encode()
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -769,7 +776,7 @@ func (dsa DedicatedServerApi) ListCredentialsByType(ctx context.Context, serverI
 func (dsa DedicatedServerApi) GetCredential(ctx context.Context, serverId, credentialType, username string) (*Credential, error) {
 	result := &Credential{}
 	path := dsa.getPath("/servers/" + serverId + "/credentials/" + credentialType + "/" + username)
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -777,14 +784,14 @@ func (dsa DedicatedServerApi) GetCredential(ctx context.Context, serverId, crede
 
 func (dsa DedicatedServerApi) DeleteCredential(ctx context.Context, serverId, credentialType, username string) error {
 	path := dsa.getPath("/servers/" + serverId + "/credentials/" + credentialType + "/" + username)
-	return doRequest(ctx, http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (dsa DedicatedServerApi) UpdateCredential(ctx context.Context, serverId, credentialType, username, password string) (*Credential, error) {
 	result := &Credential{}
 	payload := map[string]string{"password": password}
 	path := dsa.getPath("/servers/" + serverId + "/credentials/" + credentialType + "/" + username)
-	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -805,9 +812,10 @@ func (dsa DedicatedServerApi) GetDataTrafficMetrics(ctx context.Context, serverI
 		v.Add("to", fmt.Sprint(args[3]))
 	}
 
-	path := dsa.getPath("/servers/" + serverId + "/metrics/datatraffic?" + v.Encode())
+	path := dsa.getPath("/servers/" + serverId + "/metrics/datatraffic")
+	query := v.Encode()
 	result := &DataTrafficMetricsV1{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -828,9 +836,10 @@ func (dsa DedicatedServerApi) GetBandWidthMetrics(ctx context.Context, serverId 
 		v.Add("to", fmt.Sprint(args[3]))
 	}
 
-	path := dsa.getPath("/servers/" + serverId + "/metrics/bandwidth?" + v.Encode())
+	path := dsa.getPath("/servers/" + serverId + "/metrics/bandwidth")
+	query := v.Encode()
 	result := &BandWidthMetrics{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -846,8 +855,9 @@ func (dsa DedicatedServerApi) ListBandWidthNotificationSettings(ctx context.Cont
 	}
 
 	result := &BandWidthNotificationSettings{}
-	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/bandwidth?" + v.Encode())
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/bandwidth")
+	query := v.Encode()
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -862,7 +872,7 @@ func (dsa DedicatedServerApi) CreateBandWidthNotificationSetting(ctx context.Con
 	}
 	result := &NotificationSetting{}
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/bandwidth")
-	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -870,13 +880,13 @@ func (dsa DedicatedServerApi) CreateBandWidthNotificationSetting(ctx context.Con
 
 func (dsa DedicatedServerApi) DeleteBandWidthNotificationSetting(ctx context.Context, serverId, notificationId string) error {
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/bandwidth/" + notificationId)
-	return doRequest(ctx, http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (dsa DedicatedServerApi) GetBandWidthNotificationSetting(ctx context.Context, serverId, notificationId string) (*NotificationSetting, error) {
 	result := &NotificationSetting{}
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/bandwidth/" + notificationId)
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -885,7 +895,7 @@ func (dsa DedicatedServerApi) GetBandWidthNotificationSetting(ctx context.Contex
 func (dsa DedicatedServerApi) UpdateBandWidthNotificationSetting(ctx context.Context, serverId, notificationSettingId string, payload map[string]string) (*NotificationSetting, error) {
 	result := &NotificationSetting{}
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/bandwidth/" + notificationSettingId)
-	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -901,8 +911,9 @@ func (dsa DedicatedServerApi) ListDataTrafficNotificationSettings(ctx context.Co
 	}
 
 	result := &DataTrafficNotificationSettings{}
-	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/datatraffic?" + v.Encode())
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/datatraffic")
+	query := v.Encode()
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -916,7 +927,7 @@ func (dsa DedicatedServerApi) CreateDataTrafficNotificationSetting(ctx context.C
 	}
 	result := &NotificationSetting{}
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/datatraffic")
-	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -924,13 +935,13 @@ func (dsa DedicatedServerApi) CreateDataTrafficNotificationSetting(ctx context.C
 
 func (dsa DedicatedServerApi) DeleteDataTrafficNotificationSetting(ctx context.Context, serverId, notificationId string) error {
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/datatraffic/" + notificationId)
-	return doRequest(ctx, http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (dsa DedicatedServerApi) GetDataTrafficNotificationSetting(ctx context.Context, serverId, notificationId string) (*NotificationSetting, error) {
 	result := &NotificationSetting{}
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/datatraffic/" + notificationId)
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -939,7 +950,7 @@ func (dsa DedicatedServerApi) GetDataTrafficNotificationSetting(ctx context.Cont
 func (dsa DedicatedServerApi) UpdateDataTrafficNotificationSetting(ctx context.Context, serverId, notificationSettingId string, payload map[string]string) (*NotificationSetting, error) {
 	result := &NotificationSetting{}
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/datatraffic/" + notificationSettingId)
-	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -948,7 +959,7 @@ func (dsa DedicatedServerApi) UpdateDataTrafficNotificationSetting(ctx context.C
 func (dsa DedicatedServerApi) GetDdosNotificationSetting(ctx context.Context, serverId string) (*DdosNotificationSetting, error) {
 	result := &DdosNotificationSetting{}
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/ddos")
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -956,7 +967,7 @@ func (dsa DedicatedServerApi) GetDdosNotificationSetting(ctx context.Context, se
 
 func (dsa DedicatedServerApi) UpdateDdosNotificationSetting(ctx context.Context, serverId string, payload map[string]string) error {
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/ddos/")
-	if err := doRequest(ctx, http.MethodPut, path, nil, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, "", nil, payload); err != nil {
 		return err
 	}
 	return nil
@@ -964,13 +975,13 @@ func (dsa DedicatedServerApi) UpdateDdosNotificationSetting(ctx context.Context,
 
 func (dsa DedicatedServerApi) PowerCycleServer(ctx context.Context, serverId string) error {
 	path := dsa.getPath("/servers/" + serverId + "/powerCycle")
-	return doRequest(ctx, http.MethodPost, path)
+	return doRequest(ctx, http.MethodPost, path, "")
 }
 
 func (dsa DedicatedServerApi) GetPowerStatus(ctx context.Context, serverId string) (*PowerStatus, error) {
 	result := &PowerStatus{}
 	path := dsa.getPath("/servers/" + serverId + "/powerInfo")
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -978,12 +989,12 @@ func (dsa DedicatedServerApi) GetPowerStatus(ctx context.Context, serverId strin
 
 func (dsa DedicatedServerApi) PowerOffServer(ctx context.Context, serverId string) error {
 	path := dsa.getPath("/servers/" + serverId + "/powerOff")
-	return doRequest(ctx, http.MethodPost, path)
+	return doRequest(ctx, http.MethodPost, path, "")
 }
 
 func (dsa DedicatedServerApi) PowerOnServer(ctx context.Context, serverId string) error {
 	path := dsa.getPath("/servers/" + serverId + "/powerOn")
-	return doRequest(ctx, http.MethodPost, path)
+	return doRequest(ctx, http.MethodPost, path, "")
 }
 
 func (dsa DedicatedServerApi) ListOperatingSystems(ctx context.Context, args ...interface{}) (*DedicatedServerOperatingSystems, error) {
@@ -999,8 +1010,9 @@ func (dsa DedicatedServerApi) ListOperatingSystems(ctx context.Context, args ...
 	}
 
 	result := &DedicatedServerOperatingSystems{}
-	path := dsa.getPath("/operatingSystems?" + v.Encode())
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	path := dsa.getPath("/operatingSystems")
+	query := v.Encode()
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -1010,8 +1022,9 @@ func (dsa DedicatedServerApi) GetOperatingSystem(ctx context.Context, operatingS
 	v := url.Values{}
 	v.Add("controlPanelId", fmt.Sprint(controlPanelId))
 	result := &DedicatedServerOperatingSystem{}
-	path := dsa.getPath("/operatingSystems/" + operatingSystemId + "?" + v.Encode())
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	path := dsa.getPath("/operatingSystems/" + operatingSystemId)
+	query := v.Encode()
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -1030,8 +1043,9 @@ func (dsa DedicatedServerApi) ListControlPanels(ctx context.Context, args ...int
 	}
 
 	result := &DedicatedServerControlPanels{}
-	path := dsa.getPath("/controlPanels?" + v.Encode())
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	path := dsa.getPath("/controlPanels")
+	query := v.Encode()
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -1047,8 +1061,9 @@ func (dsa DedicatedServerApi) ListRescueImages(ctx context.Context, args ...inte
 	}
 
 	result := &DedicatedServerRescueImages{}
-	path := dsa.getPath("/rescueImages?" + v.Encode())
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	path := dsa.getPath("/rescueImages")
+	query := v.Encode()
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil

--- a/floating_ip.go
+++ b/floating_ip.go
@@ -70,9 +70,10 @@ func (fia FloatingIpApi) ListRanges(ctx context.Context, args ...interface{}) (*
 		v.Add("location", fmt.Sprint(args[1]))
 	}
 
-	path := fia.getPath("/ranges?" + v.Encode())
+	path := fia.getPath("/ranges")
+	query := v.Encode()
 	result := &FloatingIpRanges{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -81,7 +82,7 @@ func (fia FloatingIpApi) ListRanges(ctx context.Context, args ...interface{}) (*
 func (fia FloatingIpApi) GetRange(ctx context.Context, rangeId string) (*FloatingIpRange, error) {
 	path := fia.getPath("/ranges/" + rangeId)
 	result := &FloatingIpRange{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -107,9 +108,10 @@ func (fia FloatingIpApi) ListRangeDefinitions(ctx context.Context, rangeId strin
 		v.Add("location", fmt.Sprint(args[1]))
 	}
 
-	path := fia.getPath("/ranges/" + rangeId + "/floatingIpDefinitions?" + v.Encode())
+	path := fia.getPath("/ranges/" + rangeId + "/floatingIpDefinitions")
+	query := v.Encode()
 	result := &FloatingIpDefinitions{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -119,7 +121,7 @@ func (fia FloatingIpApi) CreateRangeDefinition(ctx context.Context, rangeId stri
 	payload := map[string]string{"floatingIp": floatingIp, "anchorIp": anchorIp}
 	path := fia.getPath("/ranges/" + rangeId + "/floatingIpDefinitions")
 	result := &FloatingIpDefinition{}
-	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -128,7 +130,7 @@ func (fia FloatingIpApi) CreateRangeDefinition(ctx context.Context, rangeId stri
 func (fia FloatingIpApi) GetRangeDefinition(ctx context.Context, rangeId string, floatingIpDefinitionId string) (*FloatingIpDefinition, error) {
 	path := fia.getPath("/ranges/" + rangeId + "/floatingIpDefinitions/" + floatingIpDefinitionId)
 	result := &FloatingIpDefinition{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -138,7 +140,7 @@ func (fia FloatingIpApi) UpdateRangeDefinition(ctx context.Context, rangeId stri
 	payload := map[string]string{"anchorIp": anchorIp}
 	path := fia.getPath("/ranges/" + rangeId + "/floatingIpDefinitions/" + floatingIpDefinitionId)
 	result := &FloatingIpDefinition{}
-	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -147,7 +149,7 @@ func (fia FloatingIpApi) UpdateRangeDefinition(ctx context.Context, rangeId stri
 func (fia FloatingIpApi) RemoveRangeDefinition(ctx context.Context, rangeId string, floatingIpDefinitionId string) (*FloatingIpDefinition, error) {
 	path := fia.getPath("/ranges/" + rangeId + "/floatingIpDefinitions/" + floatingIpDefinitionId)
 	result := &FloatingIpDefinition{}
-	if err := doRequest(ctx, http.MethodDelete, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodDelete, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/hosting.go
+++ b/hosting.go
@@ -159,9 +159,10 @@ func (ha HostingApi) ListDomains(ctx context.Context, args ...interface{}) (*Hos
 		v.Add("type", fmt.Sprint(args[1]))
 	}
 
-	path := ha.getPath("/domains?" + v.Encode())
+	path := ha.getPath("/domains")
+	query := v.Encode()
 	result := &HostingDomains{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -170,7 +171,7 @@ func (ha HostingApi) ListDomains(ctx context.Context, args ...interface{}) (*Hos
 func (ha HostingApi) GetDomain(ctx context.Context, domainName string) (*HostingDomain, error) {
 	path := ha.getPath("/domains/" + domainName)
 	result := &HostingDomain{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -179,7 +180,7 @@ func (ha HostingApi) GetDomain(ctx context.Context, domainName string) (*Hosting
 func (ha HostingApi) GetAvailability(ctx context.Context, domainName string) (*HostingDomainAvailability, error) {
 	path := ha.getPath("/domains/" + domainName + "/available")
 	result := &HostingDomainAvailability{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -194,9 +195,10 @@ func (ha HostingApi) ListNameservers(ctx context.Context, domainName string, arg
 		v.Add("limit", fmt.Sprint(args[1]))
 	}
 
-	path := ha.getPath("/domains/" + domainName + "/nameservers?" + v.Encode())
+	path := ha.getPath("/domains/" + domainName + "/nameservers")
+	query := v.Encode()
 	result := &HostingNameservers{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -207,7 +209,7 @@ func (ha HostingApi) UpdateNameservers(ctx context.Context, domainName string, n
 	payload["nameservers"] = nameservers
 	path := ha.getPath("/domains/" + domainName + "/nameservers")
 	result := &HostingNameservers{}
-	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -216,7 +218,7 @@ func (ha HostingApi) UpdateNameservers(ctx context.Context, domainName string, n
 func (ha HostingApi) GetDnsSecurity(ctx context.Context, domainName string) (*HostingDnsSecurity, error) {
 	path := ha.getPath("/domains/" + domainName + "/dnssec")
 	result := &HostingDnsSecurity{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -225,7 +227,7 @@ func (ha HostingApi) GetDnsSecurity(ctx context.Context, domainName string) (*Ho
 func (ha HostingApi) UpdateDnsSecurity(ctx context.Context, domainName string, payload map[string]interface{}) (*HostingInfoMessageResponse, error) {
 	path := ha.getPath("/domains/" + domainName + "/dnssec")
 	result := &HostingInfoMessageResponse{}
-	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -240,9 +242,10 @@ func (ha HostingApi) ListResourceRecordSets(ctx context.Context, domainName stri
 		v.Add("limit", fmt.Sprint(args[1]))
 	}
 
-	path := ha.getPath("/domains/" + domainName + "/resourceRecordSets?" + v.Encode())
+	path := ha.getPath("/domains/" + domainName + "/resourceRecordSets")
+	query := v.Encode()
 	result := &HostingResourceRecordSets{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -251,7 +254,7 @@ func (ha HostingApi) ListResourceRecordSets(ctx context.Context, domainName stri
 func (ha HostingApi) CreateResourceRecordSet(ctx context.Context, domainName string, payload map[string]interface{}) (*HostingResourceRecordSet, error) {
 	path := ha.getPath("/domains/" + domainName + "/resourceRecordSets")
 	result := &HostingResourceRecordSet{}
-	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -259,13 +262,13 @@ func (ha HostingApi) CreateResourceRecordSet(ctx context.Context, domainName str
 
 func (ha HostingApi) DeleteResourceRecordSets(ctx context.Context, domainName string) error {
 	path := ha.getPath("/domains/" + domainName + "/resourceRecordSets")
-	return doRequest(ctx, http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (ha HostingApi) GetResourceRecordSet(ctx context.Context, domainName, name, recordType string) (*HostingResourceRecordSet, error) {
 	path := ha.getPath("/domains/" + domainName + "/resourceRecordSets/" + name + "/" + recordType)
 	result := &HostingResourceRecordSet{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -277,7 +280,7 @@ func (ha HostingApi) UpdateResourceRecordSet(ctx context.Context, domainName, na
 	payload := make(map[string]interface{})
 	payload["content"] = content
 	payload["ttl"] = ttl
-	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -285,7 +288,7 @@ func (ha HostingApi) UpdateResourceRecordSet(ctx context.Context, domainName, na
 
 func (ha HostingApi) DeleteResourceRecordSet(ctx context.Context, domainName, name, recordType string) error {
 	path := ha.getPath("/domains/" + domainName + "/resourceRecordSets/" + name + "/" + recordType)
-	return doRequest(ctx, http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (ha HostingApi) ValidateResourceRecordSet(ctx context.Context, domainName, name, recordType string, content []string, ttl int) (*HostingInfoMessageResponse, error) {
@@ -296,7 +299,7 @@ func (ha HostingApi) ValidateResourceRecordSet(ctx context.Context, domainName, 
 	payload["type"] = recordType
 	payload["content"] = content
 	payload["ttl"] = ttl
-	if err := doRequest(ctx, http.MethodPost, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -305,7 +308,7 @@ func (ha HostingApi) ValidateResourceRecordSet(ctx context.Context, domainName, 
 func (ha HostingApi) ListCatchAll(ctx context.Context, domainName string) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/catchAll")
 	result := &HostingEmail{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -314,7 +317,7 @@ func (ha HostingApi) ListCatchAll(ctx context.Context, domainName string) (*Host
 func (ha HostingApi) UpdateCatchAll(ctx context.Context, domainName string, payload map[string]interface{}) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/catchAll")
 	result := &HostingEmail{}
-	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -326,7 +329,7 @@ func (ha HostingApi) CreateCatchAll(ctx context.Context, domainName string, payl
 
 func (ha HostingApi) DeleteCatchAll(ctx context.Context, domainName string) error {
 	path := ha.getPath("/domains/" + domainName + "/catchAll")
-	return doRequest(ctx, http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (ha HostingApi) ListEmailAliases(ctx context.Context, domainName string, args ...interface{}) (*HostingEmailAliases, error) {
@@ -338,9 +341,10 @@ func (ha HostingApi) ListEmailAliases(ctx context.Context, domainName string, ar
 		v.Add("limit", fmt.Sprint(args[1]))
 	}
 
-	path := ha.getPath("/domains/" + domainName + "/emailAliases?" + v.Encode())
+	path := ha.getPath("/domains/" + domainName + "/emailAliases")
+	query := v.Encode()
 	result := &HostingEmailAliases{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -349,7 +353,7 @@ func (ha HostingApi) ListEmailAliases(ctx context.Context, domainName string, ar
 func (ha HostingApi) CreateEmailAlias(ctx context.Context, domainName string, payload map[string]interface{}) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/emailAliases")
 	result := &HostingEmail{}
-	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -358,7 +362,7 @@ func (ha HostingApi) CreateEmailAlias(ctx context.Context, domainName string, pa
 func (ha HostingApi) GetEmailAlias(ctx context.Context, domainName, source, destination string) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/emailAliases/" + source + "/" + destination)
 	result := &HostingEmail{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -367,7 +371,7 @@ func (ha HostingApi) GetEmailAlias(ctx context.Context, domainName, source, dest
 func (ha HostingApi) UpdateEmailAlias(ctx context.Context, domainName, source, destination string, payload map[string]bool) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/emailAliases/" + source + "/" + destination)
 	result := &HostingEmail{}
-	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -375,7 +379,7 @@ func (ha HostingApi) UpdateEmailAlias(ctx context.Context, domainName, source, d
 
 func (ha HostingApi) DeleteEmailAlias(ctx context.Context, domainName, source, destination string) error {
 	path := ha.getPath("/domains/" + domainName + "/emailAliases/" + source + "/" + destination)
-	return doRequest(ctx, http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (ha HostingApi) ListDomainForwards(ctx context.Context, domainName string, args ...interface{}) (*HostingEmailForwards, error) {
@@ -387,9 +391,10 @@ func (ha HostingApi) ListDomainForwards(ctx context.Context, domainName string, 
 		v.Add("limit", fmt.Sprint(args[1]))
 	}
 
-	path := ha.getPath("/domains/" + domainName + "/forwards?" + v.Encode())
+	path := ha.getPath("/domains/" + domainName + "/forwards")
+	query := v.Encode()
 	result := &HostingEmailForwards{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -404,9 +409,10 @@ func (ha HostingApi) ListMailBoxes(ctx context.Context, domainName string, args 
 		v.Add("limit", fmt.Sprint(args[1]))
 	}
 
-	path := ha.getPath("/domains/" + domainName + "/mailboxes?" + v.Encode())
+	path := ha.getPath("/domains/" + domainName + "/mailboxes")
+	query := v.Encode()
 	result := &HostingEmailMailboxes{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -415,7 +421,7 @@ func (ha HostingApi) ListMailBoxes(ctx context.Context, domainName string, args 
 func (ha HostingApi) CreateMailBox(ctx context.Context, domainName string, payload map[string]interface{}) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes")
 	result := &HostingEmail{}
-	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -424,7 +430,7 @@ func (ha HostingApi) CreateMailBox(ctx context.Context, domainName string, paylo
 func (ha HostingApi) GetMailBox(ctx context.Context, domainName, emailAddress string) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress)
 	result := &HostingEmail{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -433,7 +439,7 @@ func (ha HostingApi) GetMailBox(ctx context.Context, domainName, emailAddress st
 func (ha HostingApi) UpdateMailBox(ctx context.Context, domainName, emailAddress string, payload map[string]interface{}) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress)
 	result := &HostingEmail{}
-	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -441,13 +447,13 @@ func (ha HostingApi) UpdateMailBox(ctx context.Context, domainName, emailAddress
 
 func (ha HostingApi) DeleteMailBox(ctx context.Context, domainName, emailAddress string) error {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress)
-	return doRequest(ctx, http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (ha HostingApi) GetAutoResponder(ctx context.Context, domainName, emailAddress string) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress + "/autoResponder")
 	result := &HostingEmail{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -456,7 +462,7 @@ func (ha HostingApi) GetAutoResponder(ctx context.Context, domainName, emailAddr
 func (ha HostingApi) UpdateAutoResponder(ctx context.Context, domainName, emailAddress string, payload map[string]interface{}) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress + "/autoResponder")
 	result := &HostingEmail{}
-	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -468,7 +474,7 @@ func (ha HostingApi) CreateAutoResponder(ctx context.Context, domainName, emailA
 
 func (ha HostingApi) DeleteAutoResponder(ctx context.Context, domainName, emailAddress string) error {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress + "/autoResponder")
-	return doRequest(ctx, http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (ha HostingApi) ListForwards(ctx context.Context, domainName, emailAddress string, args ...interface{}) (*HostingEmailForwards, error) {
@@ -480,9 +486,10 @@ func (ha HostingApi) ListForwards(ctx context.Context, domainName, emailAddress 
 		v.Add("limit", fmt.Sprint(args[1]))
 	}
 
-	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress + "/forwards?" + v.Encode())
+	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress + "/forwards")
+	query := v.Encode()
 	result := &HostingEmailForwards{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -491,7 +498,7 @@ func (ha HostingApi) ListForwards(ctx context.Context, domainName, emailAddress 
 func (ha HostingApi) CreateForward(ctx context.Context, domainName, emailAddress string, payload map[string]interface{}) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress + "/forwards")
 	result := &HostingEmail{}
-	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -500,7 +507,7 @@ func (ha HostingApi) CreateForward(ctx context.Context, domainName, emailAddress
 func (ha HostingApi) GetForward(ctx context.Context, domainName, emailAddress, destination string) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress + "/forwards/" + destination)
 	result := &HostingEmail{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -509,7 +516,7 @@ func (ha HostingApi) GetForward(ctx context.Context, domainName, emailAddress, d
 func (ha HostingApi) UpdateForward(ctx context.Context, domainName, emailAddress, destination string, payload map[string]bool) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress + "/forwards/" + destination)
 	result := &HostingEmail{}
-	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -517,5 +524,5 @@ func (ha HostingApi) UpdateForward(ctx context.Context, domainName, emailAddress
 
 func (ha HostingApi) DeleteForward(ctx context.Context, domainName, emailAddress, destination string) error {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress + "/forwards/" + destination)
-	return doRequest(ctx, http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path, "")
 }

--- a/invoice.go
+++ b/invoice.go
@@ -83,9 +83,10 @@ func (ia InvoiceApi) List(ctx context.Context, args ...int) (*Invoices, error) {
 		v.Add("limit", fmt.Sprint(args[1]))
 	}
 
-	path := ia.getPath("/invoices?" + v.Encode())
+	path := ia.getPath("/invoices")
+	query := v.Encode()
 	result := &Invoices{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -100,9 +101,10 @@ func (ia InvoiceApi) ListProForma(ctx context.Context, args ...int) (*InvoicePro
 		v.Add("limit", fmt.Sprint(args[1]))
 	}
 
-	path := ia.getPath("/invoices/proforma?" + v.Encode())
+	path := ia.getPath("/invoices/proforma")
+	query := v.Encode()
 	result := &InvoiceProForma{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -111,7 +113,7 @@ func (ia InvoiceApi) ListProForma(ctx context.Context, args ...int) (*InvoicePro
 func (ia InvoiceApi) Get(ctx context.Context, invoiceId string) (*Invoice, error) {
 	path := ia.getPath("/invoices/" + invoiceId)
 	result := &Invoice{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/ip_management.go
+++ b/ip_management.go
@@ -22,9 +22,10 @@ func (ima IpManagementApi) List(ctx context.Context, params ...map[string]interf
 			v.Add(key, fmt.Sprint(value))
 		}
 	}
-	path := ima.getPath("/ips?" + v.Encode())
+	path := ima.getPath("/ips")
+	query := v.Encode()
 	result := &Ips{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -33,7 +34,7 @@ func (ima IpManagementApi) List(ctx context.Context, params ...map[string]interf
 func (ima IpManagementApi) Get(ctx context.Context, ip string) (*Ip, error) {
 	path := ima.getPath("/ips/" + ip)
 	result := &Ip{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -43,7 +44,7 @@ func (ima IpManagementApi) Update(ctx context.Context, ip, reverseLookup string)
 	payload := map[string]string{"reverseLookup": reverseLookup}
 	path := ima.getPath("/ips/" + ip)
 	result := &Ip{}
-	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -58,7 +59,7 @@ func (ima IpManagementApi) NullRouteAnIp(ctx context.Context, ip string, params 
 	}
 	path := ima.getPath("/ips/" + ip + "/nullRoute")
 	result := &NullRoute{}
-	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -66,7 +67,7 @@ func (ima IpManagementApi) NullRouteAnIp(ctx context.Context, ip string, params 
 
 func (ima IpManagementApi) RemoveNullRouteAnIp(ctx context.Context, ip string) error {
 	path := ima.getPath("/ips/" + ip + "/nullRoute")
-	return doRequest(ctx, http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (ima IpManagementApi) ListNullRoutes(ctx context.Context, params ...map[string]interface{}) (*NullRoutes, error) {
@@ -76,9 +77,10 @@ func (ima IpManagementApi) ListNullRoutes(ctx context.Context, params ...map[str
 			v.Add(key, fmt.Sprint(value))
 		}
 	}
-	path := ima.getPath("/nullRoutes?" + v.Encode())
+	path := ima.getPath("/nullRoutes")
+	query := v.Encode()
 	result := &NullRoutes{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -87,7 +89,7 @@ func (ima IpManagementApi) ListNullRoutes(ctx context.Context, params ...map[str
 func (ima IpManagementApi) GetNullRoute(ctx context.Context, id string) (*NullRoute, error) {
 	path := ima.getPath("/nullRoutes/" + id)
 	result := &NullRoute{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -102,7 +104,7 @@ func (ima IpManagementApi) UpdateNullRoute(ctx context.Context, id string, param
 	}
 	path := ima.getPath("/nullRoutes/" + id)
 	result := &NullRoute{}
-	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/private_cloud.go
+++ b/private_cloud.go
@@ -68,9 +68,10 @@ func (pca PrivateCloudApi) List(ctx context.Context, args ...interface{}) (*Priv
 		v.Add("limit", fmt.Sprint(args[1]))
 	}
 
-	path := pca.getPath("/privateClouds?" + v.Encode())
+	path := pca.getPath("/privateClouds")
+	query := v.Encode()
 	result := &PrivateClouds{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -79,7 +80,7 @@ func (pca PrivateCloudApi) List(ctx context.Context, args ...interface{}) (*Priv
 func (pca PrivateCloudApi) Get(ctx context.Context, privateCloudId string) (*PrivateCloud, error) {
 	path := pca.getPath("/privateClouds/" + privateCloudId)
 	result := &PrivateCloud{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -94,9 +95,10 @@ func (pca PrivateCloudApi) ListCredentials(ctx context.Context, privateCloudId s
 		v.Add("limit", fmt.Sprint(args[1]))
 	}
 
-	path := pca.getPath("/privateClouds/" + privateCloudId + "/credentials/" + credentialType + v.Encode())
+	path := pca.getPath("/privateClouds/" + privateCloudId + "/credentials/" + credentialType)
+	query := v.Encode()
 	result := &Credentials{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -105,7 +107,7 @@ func (pca PrivateCloudApi) ListCredentials(ctx context.Context, privateCloudId s
 func (pca PrivateCloudApi) GetCredential(ctx context.Context, privateCloudId string, credentialType string, username string) (*Credential, error) {
 	path := pca.getPath("/privateClouds/" + privateCloudId + "/credentials/" + credentialType + "/" + username)
 	result := &Credential{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -126,9 +128,10 @@ func (pca PrivateCloudApi) GetDataTrafficMetrics(ctx context.Context, privateClo
 		v.Add("to", fmt.Sprint(args[3]))
 	}
 
-	path := pca.getPath("/privateClouds/" + privateCloudId + "/metrics/datatraffic?" + v.Encode())
+	path := pca.getPath("/privateClouds/" + privateCloudId + "/metrics/datatraffic")
+	query := v.Encode()
 	result := &DataTrafficMetricsV2{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -149,9 +152,10 @@ func (pca PrivateCloudApi) GetBandWidthMetrics(ctx context.Context, privateCloud
 		v.Add("to", fmt.Sprint(args[3]))
 	}
 
-	path := pca.getPath("/privateClouds/" + privateCloudId + "/metrics/bandwidth?" + v.Encode())
+	path := pca.getPath("/privateClouds/" + privateCloudId + "/metrics/bandwidth")
+	query := v.Encode()
 	result := &BandWidthMetrics{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -171,9 +175,10 @@ func (pca PrivateCloudApi) GetCpuMetrics(ctx context.Context, privateCloudId str
 	if len(args) >= 4 {
 		v.Add("to", fmt.Sprint(args[3]))
 	}
-	path := pca.getPath("/privateClouds/" + privateCloudId + "/metrics/cpu?" + v.Encode())
+	path := pca.getPath("/privateClouds/" + privateCloudId + "/metrics/cpu")
+	query := v.Encode()
 	result := &PrivateCloudCpuMetrics{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -193,9 +198,10 @@ func (pca PrivateCloudApi) GetMemoryMetrics(ctx context.Context, privateCloudId 
 	if len(args) >= 4 {
 		v.Add("to", fmt.Sprint(args[3]))
 	}
-	path := pca.getPath("/privateClouds/" + privateCloudId + "/metrics/memory?" + v.Encode())
+	path := pca.getPath("/privateClouds/" + privateCloudId + "/metrics/memory")
+	query := v.Encode()
 	result := &PrivateCloudMemoryMetrics{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -215,9 +221,10 @@ func (pca PrivateCloudApi) GetStorageMetrics(ctx context.Context, privateCloudId
 	if len(args) >= 4 {
 		v.Add("to", fmt.Sprint(args[3]))
 	}
-	path := pca.getPath("/privateClouds/" + privateCloudId + "/metrics/storage?" + v.Encode())
+	path := pca.getPath("/privateClouds/" + privateCloudId + "/metrics/storage")
+	query := v.Encode()
 	result := &PrivateCloudStorageMetrics{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/private_networking.go
+++ b/private_networking.go
@@ -40,9 +40,10 @@ func (pna PrivateNetworkingApi) List(ctx context.Context, args ...int) (*Private
 		v.Add("limit", fmt.Sprint(args[1]))
 	}
 
-	path := pna.getPath("/privateNetworks?" + v.Encode())
+	path := pna.getPath("/privateNetworks")
+	query := v.Encode()
 	result := &PrivateNetworks{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -54,7 +55,7 @@ func (pna PrivateNetworkingApi) Create(ctx context.Context, name string) (*Priva
 	}
 	path := pna.getPath("/privateNetworks")
 	result := &PrivateNetwork{}
-	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -63,7 +64,7 @@ func (pna PrivateNetworkingApi) Create(ctx context.Context, name string) (*Priva
 func (pna PrivateNetworkingApi) Get(ctx context.Context, id string) (*PrivateNetwork, error) {
 	path := pna.getPath("/privateNetworks/" + id)
 	result := &PrivateNetwork{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -75,7 +76,7 @@ func (pna PrivateNetworkingApi) Update(ctx context.Context, id, name string) (*P
 	}
 	path := pna.getPath("/privateNetworks")
 	result := &PrivateNetwork{}
-	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -83,7 +84,7 @@ func (pna PrivateNetworkingApi) Update(ctx context.Context, id, name string) (*P
 
 func (pna PrivateNetworkingApi) Delete(ctx context.Context, id string) error {
 	path := pna.getPath("/privateNetworks/" + id)
-	return doRequest(ctx, http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (pna PrivateNetworkingApi) ListDhcpReservations(ctx context.Context, id string, args ...int) (*PrivateNetworkingDhcpReservations, error) {
@@ -95,9 +96,10 @@ func (pna PrivateNetworkingApi) ListDhcpReservations(ctx context.Context, id str
 		v.Add("limit", fmt.Sprint(args[1]))
 	}
 
-	path := pna.getPath("/privateNetworks/" + id + "/reservations?" + v.Encode())
+	path := pna.getPath("/privateNetworks/" + id + "/reservations")
+	query := v.Encode()
 	result := &PrivateNetworkingDhcpReservations{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -111,7 +113,7 @@ func (pna PrivateNetworkingApi) CreateDhcpReservation(ctx context.Context, id, i
 	}
 	path := pna.getPath("/privateNetworks/" + id + "/reservations")
 	result := &PrivateNetworkingDhcpReservation{}
-	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -119,5 +121,5 @@ func (pna PrivateNetworkingApi) CreateDhcpReservation(ctx context.Context, id, i
 
 func (pna PrivateNetworkingApi) DeleteDhcpReservation(ctx context.Context, id, ip string) error {
 	path := pna.getPath("/privateNetworks/" + id + "/reservations/" + ip)
-	return doRequest(ctx, http.MethodDelete, path)
+	return doRequest(ctx, http.MethodDelete, path, "")
 }

--- a/remote_management.go
+++ b/remote_management.go
@@ -29,7 +29,7 @@ func (rma RemoteManagementApi) getPath(endpoint string) string {
 func (rma RemoteManagementApi) ChangeCredentials(ctx context.Context, password string) error {
 	payload := map[string]string{password: password}
 	path := rma.getPath("/remoteManagement/changeCredentials")
-	return doRequest(ctx, http.MethodPost, path, nil, payload)
+	return doRequest(ctx, http.MethodPost, path, "", nil, payload)
 }
 
 func (rma RemoteManagementApi) ListProfiles(ctx context.Context, args ...int) (*RemoteManagementProfiles, error) {
@@ -41,9 +41,10 @@ func (rma RemoteManagementApi) ListProfiles(ctx context.Context, args ...int) (*
 		v.Add("limit", fmt.Sprint(args[1]))
 	}
 
-	path := rma.getPath("/remoteManagement/profiles" + v.Encode())
+	path := rma.getPath("/remoteManagement/profiles")
+	query := v.Encode()
 	result := &RemoteManagementProfiles{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/rest.go
+++ b/rest.go
@@ -75,8 +75,12 @@ func getBaseUrl() string {
 	return DEFAULT_BASE_URL
 }
 
-func doRequest(ctx context.Context, method string, path string, args ...interface{}) error {
+func doRequest(ctx context.Context, method, path, query string, args ...interface{}) error {
 	url := getBaseUrl() + path
+	if query != "" {
+		url += "?" + query
+	}
+
 	apiContext := ApiContext{method, url}
 
 	var tmpPayload io.Reader

--- a/services.go
+++ b/services.go
@@ -62,9 +62,10 @@ func (sa ServicesApi) List(ctx context.Context, args ...int) (*Services, error) 
 		v.Add("limit", fmt.Sprint(args[1]))
 	}
 
-	path := sa.getPath("/services?" + v.Encode())
+	path := sa.getPath("/services")
+	query := v.Encode()
 	result := &Services{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -73,7 +74,7 @@ func (sa ServicesApi) List(ctx context.Context, args ...int) (*Services, error) 
 func (sa ServicesApi) ListCancellationReasons(ctx context.Context) (*ServicesCancellationReasons, error) {
 	path := sa.getPath("/services/cancellationReasons")
 	result := &ServicesCancellationReasons{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -82,7 +83,7 @@ func (sa ServicesApi) ListCancellationReasons(ctx context.Context) (*ServicesCan
 func (sa ServicesApi) Get(ctx context.Context, id string) (*Service, error) {
 	path := sa.getPath("/services/" + id)
 	result := &Service{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -94,10 +95,10 @@ func (sa ServicesApi) Cancel(ctx context.Context, id, reason, reasonCode string)
 		"reasonCode": reasonCode,
 	}
 	path := sa.getPath("/services/" + id + "/cancel")
-	return doRequest(ctx, http.MethodPost, path, nil, payload)
+	return doRequest(ctx, http.MethodPost, path, "", nil, payload)
 }
 
 func (sa ServicesApi) Uncancel(ctx context.Context, id string) error {
 	path := sa.getPath("/services/" + id + "/uncancel")
-	return doRequest(ctx, http.MethodPost, path)
+	return doRequest(ctx, http.MethodPost, path, "")
 }

--- a/virtual_server.go
+++ b/virtual_server.go
@@ -69,9 +69,10 @@ func (vsa VirtualServerApi) List(ctx context.Context, args ...int) (*VirtualServ
 		v.Add("limit", fmt.Sprint(args[1]))
 	}
 
-	path := vsa.getPath("/virtualServers?" + v.Encode())
+	path := vsa.getPath("/virtualServers")
+	query := v.Encode()
 	result := &VirtualServers{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -80,7 +81,7 @@ func (vsa VirtualServerApi) List(ctx context.Context, args ...int) (*VirtualServ
 func (vsa VirtualServerApi) Get(ctx context.Context, virtualServerId string) (*VirtualServer, error) {
 	path := vsa.getPath("/virtualServers/" + virtualServerId)
 	result := &VirtualServer{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -90,7 +91,7 @@ func (vsa VirtualServerApi) Update(ctx context.Context, virtualServerId, referen
 	payload := map[string]string{"reference": reference}
 	path := vsa.getPath("/virtualServers/" + virtualServerId)
 	result := &VirtualServer{}
-	if err := doRequest(ctx, http.MethodPut, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -99,7 +100,7 @@ func (vsa VirtualServerApi) Update(ctx context.Context, virtualServerId, referen
 func (vsa VirtualServerApi) PowerOn(ctx context.Context, virtualServerId string) (*VirtualServerResult, error) {
 	path := vsa.getPath("/virtualServers/" + virtualServerId + "/powerOn")
 	result := &VirtualServerResult{}
-	if err := doRequest(ctx, http.MethodPost, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -108,7 +109,7 @@ func (vsa VirtualServerApi) PowerOn(ctx context.Context, virtualServerId string)
 func (vsa VirtualServerApi) PowerOff(ctx context.Context, virtualServerId string) (*VirtualServerResult, error) {
 	path := vsa.getPath("/virtualServers/" + virtualServerId + "/powerOff")
 	result := &VirtualServerResult{}
-	if err := doRequest(ctx, http.MethodPost, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -117,7 +118,7 @@ func (vsa VirtualServerApi) PowerOff(ctx context.Context, virtualServerId string
 func (vsa VirtualServerApi) Reboot(ctx context.Context, virtualServerId string) (*VirtualServerResult, error) {
 	path := vsa.getPath("/virtualServers/" + virtualServerId + "/reboot")
 	result := &VirtualServerResult{}
-	if err := doRequest(ctx, http.MethodPost, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -127,7 +128,7 @@ func (vsa VirtualServerApi) Reinstall(ctx context.Context, virtualServerId, oper
 	payload := map[string]string{"operatingSystemId": operatingSystemId}
 	path := vsa.getPath("/virtualServers/" + virtualServerId + "/reinstall")
 	result := &VirtualServerResult{}
-	if err := doRequest(ctx, http.MethodPost, path, result, payload); err != nil {
+	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -136,7 +137,7 @@ func (vsa VirtualServerApi) Reinstall(ctx context.Context, virtualServerId, oper
 func (vsa VirtualServerApi) UpdateCredential(ctx context.Context, virtualServerId, username, credentialType, password string) error {
 	payload := map[string]string{"username": username, "type": credentialType, "password": password}
 	path := vsa.getPath("/virtualServers/" + virtualServerId + "/credentials")
-	return doRequest(ctx, http.MethodPut, path, nil, payload)
+	return doRequest(ctx, http.MethodPut, path, "", nil, payload)
 }
 
 func (vsa VirtualServerApi) ListCredentials(ctx context.Context, virtualServerId, credentialType string, args ...int) (*Credentials, error) {
@@ -148,9 +149,10 @@ func (vsa VirtualServerApi) ListCredentials(ctx context.Context, virtualServerId
 		v.Add("limit", fmt.Sprint(args[1]))
 	}
 
-	path := vsa.getPath("/virtualServers/" + virtualServerId + "/credentials/" + credentialType + "?" + v.Encode())
+	path := vsa.getPath("/virtualServers/" + virtualServerId + "/credentials/" + credentialType)
+	query := v.Encode()
 	result := &Credentials{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -159,7 +161,7 @@ func (vsa VirtualServerApi) ListCredentials(ctx context.Context, virtualServerId
 func (vsa VirtualServerApi) GetCredential(ctx context.Context, virtualServerId, username, credentialType string) (*Credential, error) {
 	path := vsa.getPath("/virtualServers/" + virtualServerId + "/credentials/" + credentialType + "/" + username)
 	result := &Credential{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -180,9 +182,10 @@ func (vsa VirtualServerApi) GetDataTrafficMetrics(ctx context.Context, virtualSe
 		v.Add("to", fmt.Sprint(args[3]))
 	}
 
-	path := vsa.getPath("/virtualServers/" + virtualServerId + "/metrics/datatraffic?" + v.Encode())
+	path := vsa.getPath("/virtualServers/" + virtualServerId + "/metrics/datatraffic")
+	query := v.Encode()
 	result := &DataTrafficMetricsV2{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -199,7 +202,7 @@ func (vsa VirtualServerApi) ListTemplates(ctx context.Context, virtualServerId s
 
 	path := vsa.getPath("/virtualServers/" + virtualServerId + "/templates")
 	result := &VirtualServerTemplates{}
-	if err := doRequest(ctx, http.MethodGet, path, result); err != nil {
+	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil


### PR DESCRIPTION
There were bugs in some functions where the "?" character was missing in the getPath call. Now the addition of it is centralised in the doRequest function.

This also fix the getPath naming. It is expected to only return the path of the URL and not the query part.