### PR TITLE
Make it possible to use non-global client

### DIFF
--- a/abuse.go
+++ b/abuse.go
@@ -12,7 +12,9 @@ import (
 
 const ABUSE_API_VERSION = "v1"
 
-type AbuseApi struct{}
+type AbuseApi struct {
+	Client *LeasewebClient
+}
 
 type AbuseReport struct {
 	Id                  string                    `json:"id"`
@@ -94,7 +96,8 @@ func (aba AbuseApi) List(ctx context.Context, args ...interface{}) (*AbuseReport
 	path := aba.getPath("/reports")
 	query := v.Encode()
 	result := &AbuseReports{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(aba.Client).
+		doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -103,7 +106,8 @@ func (aba AbuseApi) List(ctx context.Context, args ...interface{}) (*AbuseReport
 func (aba AbuseApi) Get(ctx context.Context, abuseReportId string) (*AbuseReport, error) {
 	path := aba.getPath("/reports/" + abuseReportId)
 	result := &AbuseReport{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(aba.Client).
+		doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -121,7 +125,8 @@ func (aba AbuseApi) ListMessages(ctx context.Context, abuseReportId string, args
 	path := aba.getPath("/reports/" + abuseReportId + "/messages")
 	query := v.Encode()
 	result := &AbuseMessages{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(aba.Client).
+		doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -131,7 +136,8 @@ func (aba AbuseApi) CreateMessage(ctx context.Context, abuseReportId string, bod
 	var result []string
 	payload := map[string]string{body: body}
 	path := aba.getPath("/reports/" + abuseReportId + "/messages")
-	if err := doRequest(ctx, http.MethodPost, path, "", &result, payload); err != nil {
+	if err := getClient(aba.Client).
+		doRequest(ctx, http.MethodPost, path, "", &result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -140,7 +146,8 @@ func (aba AbuseApi) CreateMessage(ctx context.Context, abuseReportId string, bod
 func (aba AbuseApi) ListResolutionOptions(ctx context.Context, abuseReportId string) (*AbuseResolutions, error) {
 	path := aba.getPath("/reports/" + abuseReportId + "/resolutions")
 	result := &AbuseResolutions{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(aba.Client).
+		doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -149,7 +156,8 @@ func (aba AbuseApi) ListResolutionOptions(ctx context.Context, abuseReportId str
 func (aba AbuseApi) Resolve(ctx context.Context, abuseReportId string, resolutions []string) error {
 	payload := map[string][]string{"resolutions": resolutions}
 	path := aba.getPath("/reports/" + abuseReportId + "/resolve")
-	return doRequest(ctx, http.MethodPost, path, "", nil, payload)
+	return getClient(aba.Client).
+		doRequest(ctx, http.MethodPost, path, "", nil, payload)
 }
 
 // TODO

--- a/customer_account.go
+++ b/customer_account.go
@@ -11,7 +11,9 @@ import (
 
 const CUSTOMER_ACCOUNT_API_VERSION = "v1"
 
-type CustomerAccountApi struct{}
+type CustomerAccountApi struct {
+	Client *LeasewebClient
+}
 
 type CustomerAccount struct {
 	Name         string                 `json:"name"`
@@ -60,7 +62,8 @@ func (cai CustomerAccountApi) getPath(endpoint string) string {
 func (cai CustomerAccountApi) Get(ctx context.Context) (*CustomerAccount, error) {
 	path := cai.getPath("/details")
 	result := &CustomerAccount{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(cai.Client).
+		doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -69,7 +72,8 @@ func (cai CustomerAccountApi) Get(ctx context.Context) (*CustomerAccount, error)
 func (cai CustomerAccountApi) Update(ctx context.Context, ad CustomerAccountAddress) error {
 	path := cai.getPath("/details")
 	payload := map[string]CustomerAccountAddress{"address": ad}
-	return doRequest(ctx, http.MethodPut, path, "", nil, payload)
+	return getClient(cai.Client).
+		doRequest(ctx, http.MethodPut, path, "", nil, payload)
 }
 
 func (cai CustomerAccountApi) ListContacts(ctx context.Context, args ...interface{}) (*CustomerAccountContacts, error) {
@@ -92,7 +96,8 @@ func (cai CustomerAccountApi) ListContacts(ctx context.Context, args ...interfac
 	path := cai.getPath("/contacts")
 	query := v.Encode()
 	result := &CustomerAccountContacts{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(cai.Client).
+		doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -101,7 +106,8 @@ func (cai CustomerAccountApi) ListContacts(ctx context.Context, args ...interfac
 func (cai CustomerAccountApi) CreateContact(ctx context.Context, newContact CustomerAccountContact) (*CustomerAccountContact, error) {
 	path := cai.getPath("/contacts")
 	result := &CustomerAccountContact{}
-	if err := doRequest(ctx, http.MethodPost, path, "", result, newContact); err != nil {
+	if err := getClient(cai.Client).
+		doRequest(ctx, http.MethodPost, path, "", result, newContact); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -109,13 +115,14 @@ func (cai CustomerAccountApi) CreateContact(ctx context.Context, newContact Cust
 
 func (cai CustomerAccountApi) DeleteContact(ctx context.Context, contactId string) error {
 	path := cai.getPath("/contacts/" + contactId)
-	return doRequest(ctx, http.MethodDelete, path, "")
+	return getClient(cai.Client).
+		doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (cai CustomerAccountApi) GetContact(ctx context.Context, contactId string) (*CustomerAccountContact, error) {
 	path := cai.getPath("/contacts/" + contactId)
 	result := &CustomerAccountContact{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(cai.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -133,11 +140,13 @@ func (cai CustomerAccountApi) UpdateContact(ctx context.Context, contactId strin
 	}
 
 	path := cai.getPath("/contacts" + contactId)
-	return doRequest(ctx, http.MethodPut, path, "", nil, payload)
+	return getClient(cai.Client).
+		doRequest(ctx, http.MethodPut, path, "", nil, payload)
 }
 
 func (cai CustomerAccountApi) AssignPrimaryRolesToContact(ctx context.Context, contactId string, roles []string) error {
 	payload := map[string][]string{"roles": roles}
 	path := cai.getPath("/contacts" + contactId)
-	return doRequest(ctx, http.MethodPost, path, "", nil, payload)
+	return getClient(cai.Client).
+		doRequest(ctx, http.MethodPost, path, "", nil, payload)
 }

--- a/dedicated_network_equipment.go
+++ b/dedicated_network_equipment.go
@@ -9,7 +9,9 @@ import (
 
 const DEDICATED_NETWORK_EQUIPMENT_API_VERSION = "v2"
 
-type DedicatedNetworkEquipmentApi struct{}
+type DedicatedNetworkEquipmentApi struct {
+	Client *LeasewebClient
+}
 
 type DedicatedNetworkEquipments struct {
 	NetworkEquipments []DedicatedNetworkEquipment `json:"networkEquipments"`
@@ -74,7 +76,7 @@ func (dnea DedicatedNetworkEquipmentApi) List(ctx context.Context, args ...inter
 	path := dnea.getPath("/networkEquipments")
 	query := v.Encode()
 	result := &DedicatedNetworkEquipments{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(dnea.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -83,7 +85,7 @@ func (dnea DedicatedNetworkEquipmentApi) List(ctx context.Context, args ...inter
 func (dnea DedicatedNetworkEquipmentApi) Get(ctx context.Context, networkEquipmentId string) (*DedicatedNetworkEquipment, error) {
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId)
 	result := &DedicatedNetworkEquipment{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(dnea.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -92,7 +94,7 @@ func (dnea DedicatedNetworkEquipmentApi) Get(ctx context.Context, networkEquipme
 func (dnea DedicatedNetworkEquipmentApi) Update(ctx context.Context, networkEquipmentId, reference string) error {
 	payload := map[string]string{"reference": reference}
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId)
-	return doRequest(ctx, http.MethodPut, path, "", nil, payload)
+	return getClient(dnea.Client).doRequest(ctx, http.MethodPut, path, "", nil, payload)
 }
 
 func (dnea DedicatedNetworkEquipmentApi) ListIps(ctx context.Context, networkEquipmentId string, args ...interface{}) (*Ips, error) {
@@ -119,7 +121,7 @@ func (dnea DedicatedNetworkEquipmentApi) ListIps(ctx context.Context, networkEqu
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/ips")
 	query := v.Encode()
 	result := &Ips{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(dnea.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -128,7 +130,7 @@ func (dnea DedicatedNetworkEquipmentApi) ListIps(ctx context.Context, networkEqu
 func (dnea DedicatedNetworkEquipmentApi) GetIp(ctx context.Context, networkEquipmentId, ip string) (*Ip, error) {
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/ips/" + ip)
 	result := &Ip{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(dnea.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -137,7 +139,7 @@ func (dnea DedicatedNetworkEquipmentApi) GetIp(ctx context.Context, networkEquip
 func (dnea DedicatedNetworkEquipmentApi) UpdateIp(ctx context.Context, networkEquipmentId, ip string, payload map[string]string) (*Ip, error) {
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/ips/" + ip)
 	result := &Ip{}
-	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
+	if err := getClient(dnea.Client).doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -146,7 +148,7 @@ func (dnea DedicatedNetworkEquipmentApi) UpdateIp(ctx context.Context, networkEq
 func (dnea DedicatedNetworkEquipmentApi) NullRouteAnIp(ctx context.Context, networkEquipmentId, ip string) (*Ip, error) {
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/ips/" + ip + "/null")
 	result := &Ip{}
-	if err := doRequest(ctx, http.MethodPost, path, "", result); err != nil {
+	if err := getClient(dnea.Client).doRequest(ctx, http.MethodPost, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -155,7 +157,7 @@ func (dnea DedicatedNetworkEquipmentApi) NullRouteAnIp(ctx context.Context, netw
 func (dnea DedicatedNetworkEquipmentApi) RemoveNullRouteAnIp(ctx context.Context, networkEquipmentId, ip string) (*Ip, error) {
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/ips/" + ip + "/unnull")
 	result := &Ip{}
-	if err := doRequest(ctx, http.MethodPost, path, "", result); err != nil {
+	if err := getClient(dnea.Client).doRequest(ctx, http.MethodPost, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -173,7 +175,7 @@ func (dnea DedicatedNetworkEquipmentApi) ListNullRoutes(ctx context.Context, net
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/nullRouteHistory")
 	query := v.Encode()
 	result := &NullRoutes{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(dnea.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -191,7 +193,7 @@ func (dnea DedicatedNetworkEquipmentApi) ListCredentials(ctx context.Context, ne
 	result := &Credentials{}
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/credentials")
 	query := v.Encode()
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(dnea.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -204,7 +206,7 @@ func (dnea DedicatedNetworkEquipmentApi) CreateCredential(ctx context.Context, n
 	payload["username"] = username
 	payload["password"] = password
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/credentials")
-	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
+	if err := getClient(dnea.Client).doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -222,7 +224,7 @@ func (dnea DedicatedNetworkEquipmentApi) ListCredentialsByType(ctx context.Conte
 	result := &Credentials{}
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/credentials/" + credentialType)
 	query := v.Encode()
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(dnea.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -231,7 +233,7 @@ func (dnea DedicatedNetworkEquipmentApi) ListCredentialsByType(ctx context.Conte
 func (dnea DedicatedNetworkEquipmentApi) GetCredential(ctx context.Context, networkEquipmentId, credentialType, username string) (*Credential, error) {
 	result := &Credential{}
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/credentials/" + credentialType + "/" + username)
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(dnea.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -239,14 +241,14 @@ func (dnea DedicatedNetworkEquipmentApi) GetCredential(ctx context.Context, netw
 
 func (dnea DedicatedNetworkEquipmentApi) DeleteCredential(ctx context.Context, networkEquipmentId, credentialType, username string) error {
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/credentials/" + credentialType + "/" + username)
-	return doRequest(ctx, http.MethodDelete, path, "")
+	return getClient(dnea.Client).doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (dnea DedicatedNetworkEquipmentApi) UpdateCredential(ctx context.Context, networkEquipmentId, credentialType, username, password string) (*Credential, error) {
 	result := &Credential{}
 	payload := map[string]string{"password": password}
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/credentials/" + credentialType + "/" + username)
-	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
+	if err := getClient(dnea.Client).doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -254,13 +256,13 @@ func (dnea DedicatedNetworkEquipmentApi) UpdateCredential(ctx context.Context, n
 
 func (dnea DedicatedNetworkEquipmentApi) PowerCycleServer(ctx context.Context, networkEquipmentId string) error {
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/powerCycle")
-	return doRequest(ctx, http.MethodPost, path, "")
+	return getClient(dnea.Client).doRequest(ctx, http.MethodPost, path, "")
 }
 
 func (dnea DedicatedNetworkEquipmentApi) GetPowerStatus(ctx context.Context, networkEquipmentId string) (*PowerStatus, error) {
 	result := &PowerStatus{}
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/powerInfo")
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(dnea.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -268,10 +270,10 @@ func (dnea DedicatedNetworkEquipmentApi) GetPowerStatus(ctx context.Context, net
 
 func (dnea DedicatedNetworkEquipmentApi) PowerOffServer(ctx context.Context, networkEquipmentId string) error {
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/powerOff")
-	return doRequest(ctx, http.MethodPost, path, "")
+	return getClient(dnea.Client).doRequest(ctx, http.MethodPost, path, "")
 }
 
 func (dnea DedicatedNetworkEquipmentApi) PowerOnServer(ctx context.Context, networkEquipmentId string) error {
 	path := dnea.getPath("/networkEquipments/" + networkEquipmentId + "/powerOn")
-	return doRequest(ctx, http.MethodPost, path, "")
+	return getClient(dnea.Client).doRequest(ctx, http.MethodPost, path, "")
 }

--- a/dedicated_rack.go
+++ b/dedicated_rack.go
@@ -9,7 +9,9 @@ import (
 
 const DEDICATED_RACK_API_VERSION = "v2"
 
-type DedicatedRackApi struct{}
+type DedicatedRackApi struct {
+	Client *LeasewebClient
+}
 
 type DedicatedRacks struct {
 	PrivateRacks []DedicatedRack `json:"privateRacks"`
@@ -54,7 +56,7 @@ func (dra DedicatedRackApi) List(ctx context.Context, args ...interface{}) (*Ded
 	path := dra.getPath("/privateRacks")
 	query := v.Encode()
 	result := &DedicatedRacks{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(dra.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -63,7 +65,7 @@ func (dra DedicatedRackApi) List(ctx context.Context, args ...interface{}) (*Ded
 func (dra DedicatedRackApi) Get(ctx context.Context, privateRackId string) (*DedicatedRack, error) {
 	path := dra.getPath("/privateRacks/" + privateRackId)
 	result := &DedicatedRack{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(dra.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -72,7 +74,7 @@ func (dra DedicatedRackApi) Get(ctx context.Context, privateRackId string) (*Ded
 func (dra DedicatedRackApi) Update(ctx context.Context, privateRackId, reference string) error {
 	payload := map[string]string{"reference": reference}
 	path := dra.getPath("/privateRacks/" + privateRackId)
-	return doRequest(ctx, http.MethodPut, path, "", nil, payload)
+	return getClient(dra.Client).doRequest(ctx, http.MethodPut, path, "", nil, payload)
 }
 
 func (dra DedicatedRackApi) ListNullRoutes(ctx context.Context, privateRackId string, args ...interface{}) (*NullRoutes, error) {
@@ -87,7 +89,7 @@ func (dra DedicatedRackApi) ListNullRoutes(ctx context.Context, privateRackId st
 	path := dra.getPath("/privateRacks/" + privateRackId + "/nullRouteHistory")
 	query := v.Encode()
 	result := &NullRoutes{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(dra.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -117,7 +119,7 @@ func (dra DedicatedRackApi) ListIps(ctx context.Context, privateRackId string, a
 	path := dra.getPath("/privateRacks/" + privateRackId + "/ips")
 	query := v.Encode()
 	result := &Ips{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(dra.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -126,7 +128,7 @@ func (dra DedicatedRackApi) ListIps(ctx context.Context, privateRackId string, a
 func (dra DedicatedRackApi) GetIp(ctx context.Context, privateRackId, ip string) (*Ip, error) {
 	path := dra.getPath("/privateRacks/" + privateRackId + "/ips/" + ip)
 	result := &Ip{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(dra.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -135,7 +137,7 @@ func (dra DedicatedRackApi) GetIp(ctx context.Context, privateRackId, ip string)
 func (dra DedicatedRackApi) UpdateIp(ctx context.Context, privateRackId, ip string, payload map[string]string) (*Ip, error) {
 	path := dra.getPath("/privateRacks/" + privateRackId + "/ips/" + ip)
 	result := &Ip{}
-	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
+	if err := getClient(dra.Client).doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -144,7 +146,7 @@ func (dra DedicatedRackApi) UpdateIp(ctx context.Context, privateRackId, ip stri
 func (dra DedicatedRackApi) NullRouteAnIp(ctx context.Context, privateRackId, ip string) (*Ip, error) {
 	path := dra.getPath("/privateRacks/" + privateRackId + "/ips/" + ip + "/null")
 	result := &Ip{}
-	if err := doRequest(ctx, http.MethodPost, path, "", result); err != nil {
+	if err := getClient(dra.Client).doRequest(ctx, http.MethodPost, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -153,7 +155,7 @@ func (dra DedicatedRackApi) NullRouteAnIp(ctx context.Context, privateRackId, ip
 func (dra DedicatedRackApi) RemoveNullRouteAnIp(ctx context.Context, privateRackId, ip string) (*Ip, error) {
 	path := dra.getPath("/privateRacks/" + privateRackId + "/ips/" + ip + "/unnull")
 	result := &Ip{}
-	if err := doRequest(ctx, http.MethodPost, path, "", result); err != nil {
+	if err := getClient(dra.Client).doRequest(ctx, http.MethodPost, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -171,7 +173,7 @@ func (dra DedicatedRackApi) ListCredentials(ctx context.Context, privateRackId s
 	result := &Credentials{}
 	query := v.Encode()
 	path := dra.getPath("/privateRacks/" + privateRackId + "/credentials")
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(dra.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -184,7 +186,7 @@ func (dra DedicatedRackApi) CreateCredential(ctx context.Context, privateRackId,
 	payload["username"] = username
 	payload["password"] = password
 	path := dra.getPath("/privateRacks/" + privateRackId + "/credentials")
-	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
+	if err := getClient(dra.Client).doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -202,7 +204,7 @@ func (dra DedicatedRackApi) ListCredentialsByType(ctx context.Context, privateRa
 	result := &Credentials{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/credentials/" + credentialType)
 	query := v.Encode()
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(dra.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -211,7 +213,7 @@ func (dra DedicatedRackApi) ListCredentialsByType(ctx context.Context, privateRa
 func (dra DedicatedRackApi) GetCredential(ctx context.Context, privateRackId, credentialType, username string) (*Credential, error) {
 	result := &Credential{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/credentials/" + credentialType + "/" + username)
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(dra.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -219,14 +221,14 @@ func (dra DedicatedRackApi) GetCredential(ctx context.Context, privateRackId, cr
 
 func (dra DedicatedRackApi) DeleteCredential(ctx context.Context, privateRackId, credentialType, username string) error {
 	path := dra.getPath("/privateRacks/" + privateRackId + "/credentials/" + credentialType + "/" + username)
-	return doRequest(ctx, http.MethodDelete, path, "")
+	return getClient(dra.Client).doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (dra DedicatedRackApi) UpdateCredential(ctx context.Context, privateRackId, credentialType, username, password string) (*Credential, error) {
 	result := &Credential{}
 	payload := map[string]string{"password": password}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/credentials/" + credentialType + "/" + username)
-	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
+	if err := getClient(dra.Client).doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -250,7 +252,7 @@ func (dra DedicatedRackApi) GetDataTrafficMetrics(ctx context.Context, privateRa
 	path := dra.getPath("/privateRacks/" + privateRackId + "/metrics/datatraffic")
 	query := v.Encode()
 	result := &DataTrafficMetricsV1{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(dra.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -274,7 +276,7 @@ func (dra DedicatedRackApi) GetBandWidthMetrics(ctx context.Context, privateRack
 	path := dra.getPath("/privateRacks/" + privateRackId + "/metrics/bandwidth")
 	query := v.Encode()
 	result := &BandWidthMetrics{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(dra.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -283,7 +285,7 @@ func (dra DedicatedRackApi) GetBandWidthMetrics(ctx context.Context, privateRack
 func (dra DedicatedRackApi) GetDdosNotificationSetting(ctx context.Context, privateRackId string) (*DdosNotificationSetting, error) {
 	result := &DdosNotificationSetting{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/ddos")
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(dra.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -291,7 +293,7 @@ func (dra DedicatedRackApi) GetDdosNotificationSetting(ctx context.Context, priv
 
 func (dra DedicatedRackApi) UpdateDdosNotificationSetting(ctx context.Context, privateRackId string, payload map[string]string) error {
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/ddos")
-	if err := doRequest(ctx, http.MethodPut, path, "", nil, payload); err != nil {
+	if err := getClient(dra.Client).doRequest(ctx, http.MethodPut, path, "", nil, payload); err != nil {
 		return err
 	}
 	return nil
@@ -309,7 +311,7 @@ func (dra DedicatedRackApi) ListBandWidthNotificationSettings(ctx context.Contex
 	result := &BandWidthNotificationSettings{}
 	query := v.Encode()
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/bandwidth")
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(dra.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -323,7 +325,7 @@ func (dra DedicatedRackApi) CreateBandWidthNotificationSetting(ctx context.Conte
 	}
 	result := &NotificationSetting{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/bandwidth")
-	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
+	if err := getClient(dra.Client).doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -331,13 +333,13 @@ func (dra DedicatedRackApi) CreateBandWidthNotificationSetting(ctx context.Conte
 
 func (dra DedicatedRackApi) DeleteBandWidthNotificationSetting(ctx context.Context, privateRackId, notificationId string) error {
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/bandwidth/" + notificationId)
-	return doRequest(ctx, http.MethodDelete, path, "")
+	return getClient(dra.Client).doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (dra DedicatedRackApi) GetBandWidthNotificationSetting(ctx context.Context, privateRackId, notificationId string) (*NotificationSetting, error) {
 	result := &NotificationSetting{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/bandwidth/" + notificationId)
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(dra.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -346,7 +348,7 @@ func (dra DedicatedRackApi) GetBandWidthNotificationSetting(ctx context.Context,
 func (dra DedicatedRackApi) UpdateBandWidthNotificationSetting(ctx context.Context, privateRackId, notificationSettingId string, payload map[string]string) (*NotificationSetting, error) {
 	result := &NotificationSetting{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/bandwidth/" + notificationSettingId)
-	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
+	if err := getClient(dra.Client).doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -364,7 +366,7 @@ func (dra DedicatedRackApi) ListDataTrafficNotificationSettings(ctx context.Cont
 	result := &DataTrafficNotificationSettings{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/datatraffic")
 	query := v.Encode()
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(dra.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -378,7 +380,7 @@ func (dra DedicatedRackApi) CreateDataTrafficNotificationSetting(ctx context.Con
 	}
 	result := &NotificationSetting{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/datatraffic")
-	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
+	if err := getClient(dra.Client).doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -386,13 +388,13 @@ func (dra DedicatedRackApi) CreateDataTrafficNotificationSetting(ctx context.Con
 
 func (dra DedicatedRackApi) DeleteDataTrafficNotificationSetting(ctx context.Context, privateRackId, notificationId string) error {
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/datatraffic/" + notificationId)
-	return doRequest(ctx, http.MethodDelete, path, "")
+	return getClient(dra.Client).doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (dra DedicatedRackApi) GetDataTrafficNotificationSetting(ctx context.Context, privateRackId, notificationId string) (*NotificationSetting, error) {
 	result := &NotificationSetting{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/datatraffic/" + notificationId)
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(dra.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -401,7 +403,7 @@ func (dra DedicatedRackApi) GetDataTrafficNotificationSetting(ctx context.Contex
 func (dra DedicatedRackApi) UpdateDataTrafficNotificationSetting(ctx context.Context, privateRackId, notificationSettingId string, payload map[string]string) (*NotificationSetting, error) {
 	result := &NotificationSetting{}
 	path := dra.getPath("/privateRacks/" + privateRackId + "/notificationSettings/datatraffic/" + notificationSettingId)
-	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
+	if err := getClient(dra.Client).doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil

--- a/dedicated_server.go
+++ b/dedicated_server.go
@@ -12,7 +12,9 @@ import (
 
 const DEDICATED_SERVER_API_VERSION = "v2"
 
-type DedicatedServerApi struct{}
+type DedicatedServerApi struct {
+	Client *LeasewebClient
+}
 
 type DedicatedServers struct {
 	Servers  []DedicatedServer `json:"servers"`
@@ -437,7 +439,7 @@ func (dsa DedicatedServerApi) List(ctx context.Context, opts DedicatedServerList
 	path := dsa.getPath("/servers")
 	query := options.Encode(opts)
 	result := &DedicatedServers{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -446,7 +448,7 @@ func (dsa DedicatedServerApi) List(ctx context.Context, opts DedicatedServerList
 func (dsa DedicatedServerApi) Get(ctx context.Context, serverId string) (*DedicatedServer, error) {
 	path := dsa.getPath("/servers/" + serverId)
 	result := &DedicatedServer{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -454,13 +456,13 @@ func (dsa DedicatedServerApi) Get(ctx context.Context, serverId string) (*Dedica
 
 func (dsa DedicatedServerApi) Update(ctx context.Context, serverId string, payload map[string]interface{}) error {
 	path := dsa.getPath("/servers/" + serverId)
-	return doRequest(ctx, http.MethodPut, path, "", nil, payload)
+	return getClient(dsa.Client).doRequest(ctx, http.MethodPut, path, "", nil, payload)
 }
 
 func (dsa DedicatedServerApi) GetHardwareInformation(ctx context.Context, serverId string) (*DedicatedServerHardware, error) {
 	path := dsa.getPath("/servers/" + serverId + "/hardwareInfo")
 	result := &DedicatedServerHardware{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -490,7 +492,7 @@ func (dsa DedicatedServerApi) ListIps(ctx context.Context, serverId string, args
 	path := dsa.getPath("/servers/" + serverId + "/ips")
 	query := v.Encode()
 	result := &Ips{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -499,7 +501,7 @@ func (dsa DedicatedServerApi) ListIps(ctx context.Context, serverId string, args
 func (dsa DedicatedServerApi) GetIp(ctx context.Context, serverId, ip string) (*Ip, error) {
 	path := dsa.getPath("/servers/" + serverId + "/ips/" + ip)
 	result := &Ip{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -508,7 +510,7 @@ func (dsa DedicatedServerApi) GetIp(ctx context.Context, serverId, ip string) (*
 func (dsa DedicatedServerApi) UpdateIp(ctx context.Context, serverId, ip string, payload map[string]string) (*Ip, error) {
 	path := dsa.getPath("/servers/" + serverId + "/ips/" + ip)
 	result := &Ip{}
-	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -517,7 +519,7 @@ func (dsa DedicatedServerApi) UpdateIp(ctx context.Context, serverId, ip string,
 func (dsa DedicatedServerApi) NullRouteAnIp(ctx context.Context, serverId, ip string) (*Ip, error) {
 	path := dsa.getPath("/servers/" + serverId + "/ips/" + ip + "/null")
 	result := &Ip{}
-	if err := doRequest(ctx, http.MethodPost, path, "", result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodPost, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -526,7 +528,7 @@ func (dsa DedicatedServerApi) NullRouteAnIp(ctx context.Context, serverId, ip st
 func (dsa DedicatedServerApi) RemoveNullRouteAnIp(ctx context.Context, serverId, ip string) (*Ip, error) {
 	path := dsa.getPath("/servers/" + serverId + "/ips/" + ip + "/unnull")
 	result := &Ip{}
-	if err := doRequest(ctx, http.MethodPost, path, "", result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodPost, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -544,7 +546,7 @@ func (dsa DedicatedServerApi) ListNullRoutes(ctx context.Context, serverId strin
 	path := dsa.getPath("/servers/" + serverId + "/nullRouteHistory")
 	query := v.Encode()
 	result := &NullRoutes{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -561,7 +563,7 @@ func (dsa DedicatedServerApi) ListNetworkInterfaces(ctx context.Context, serverI
 
 	path := dsa.getPath("/servers/" + serverId + "/networkInterfaces")
 	result := &DedicatedServerNetworkInterfaces{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -569,18 +571,18 @@ func (dsa DedicatedServerApi) ListNetworkInterfaces(ctx context.Context, serverI
 
 func (dsa DedicatedServerApi) CloseAllNetworkInterfaces(ctx context.Context, serverId string) error {
 	path := dsa.getPath("/servers/" + serverId + "/networkInterfaces/close")
-	return doRequest(ctx, http.MethodPost, path, "")
+	return getClient(dsa.Client).doRequest(ctx, http.MethodPost, path, "")
 }
 
 func (dsa DedicatedServerApi) OpenAllNetworkInterfaces(ctx context.Context, serverId string) error {
 	path := dsa.getPath("/servers/" + serverId + "/networkInterfaces/open")
-	return doRequest(ctx, http.MethodPost, path, "")
+	return getClient(dsa.Client).doRequest(ctx, http.MethodPost, path, "")
 }
 
 func (dsa DedicatedServerApi) GetNetworkInterface(ctx context.Context, serverId, networkType string) (*DedicatedServerNetworkInterface, error) {
 	path := dsa.getPath("/servers/" + serverId + "/networkInterfaces/" + networkType)
 	result := &DedicatedServerNetworkInterface{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -588,28 +590,28 @@ func (dsa DedicatedServerApi) GetNetworkInterface(ctx context.Context, serverId,
 
 func (dsa DedicatedServerApi) CloseNetworkInterface(ctx context.Context, serverId, networkType string) error {
 	path := dsa.getPath("/servers/" + serverId + "/networkInterfaces/" + networkType + "/close")
-	return doRequest(ctx, http.MethodPost, path, "")
+	return getClient(dsa.Client).doRequest(ctx, http.MethodPost, path, "")
 }
 
 func (dsa DedicatedServerApi) OpenNetworkInterface(ctx context.Context, serverId, networkType string) error {
 	path := dsa.getPath("/servers/" + serverId + "/networkInterfaces/" + networkType + "/open")
-	return doRequest(ctx, http.MethodPost, path, "")
+	return getClient(dsa.Client).doRequest(ctx, http.MethodPost, path, "")
 }
 
 func (dsa DedicatedServerApi) DeleteServerFromPrivateNetwork(ctx context.Context, serverId, privateNetworkId string) error {
 	path := dsa.getPath("/servers/" + serverId + "/privateNetworks/" + privateNetworkId)
-	return doRequest(ctx, http.MethodDelete, path, "")
+	return getClient(dsa.Client).doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (dsa DedicatedServerApi) AddServerToPrivateNetwork(ctx context.Context, serverId, privateNetworkId string, linkSpeed int) error {
 	payload := map[string]int{"linkSpeed": linkSpeed}
 	path := dsa.getPath("/servers/" + serverId + "/privateNetworks/" + privateNetworkId)
-	return doRequest(ctx, http.MethodPut, path, "", nil, payload)
+	return getClient(dsa.Client).doRequest(ctx, http.MethodPut, path, "", nil, payload)
 }
 
 func (dsa DedicatedServerApi) DeleteDhcpReservation(ctx context.Context, serverId string) error {
 	path := dsa.getPath("/servers/" + serverId + "/leases")
-	return doRequest(ctx, http.MethodDelete, path, "")
+	return getClient(dsa.Client).doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (dsa DedicatedServerApi) ListDhcpReservation(ctx context.Context, serverId string, args ...interface{}) (*DedicatedServerDhcpReservations, error) {
@@ -623,7 +625,7 @@ func (dsa DedicatedServerApi) ListDhcpReservation(ctx context.Context, serverId 
 	path := dsa.getPath("/servers/" + serverId + "/leases")
 	query := v.Encode()
 	result := &DedicatedServerDhcpReservations{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -631,13 +633,13 @@ func (dsa DedicatedServerApi) ListDhcpReservation(ctx context.Context, serverId 
 
 func (dsa DedicatedServerApi) CreateDhcpReservation(ctx context.Context, serverId string, payload map[string]string) error {
 	path := dsa.getPath("/servers/" + serverId + "/leases")
-	return doRequest(ctx, http.MethodPost, path, "", nil, payload)
+	return getClient(dsa.Client).doRequest(ctx, http.MethodPost, path, "", nil, payload)
 }
 
 func (dsa DedicatedServerApi) CancelActiveJob(ctx context.Context, serverId string) (*DedicatedServerJob, error) {
 	result := &DedicatedServerJob{}
 	path := dsa.getPath("/servers/" + serverId + "/cancelActiveJob")
-	if err := doRequest(ctx, http.MethodPost, path, "", result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodPost, path, "", result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -646,7 +648,7 @@ func (dsa DedicatedServerApi) CancelActiveJob(ctx context.Context, serverId stri
 func (dsa DedicatedServerApi) ExpireActiveJob(ctx context.Context, serverId string) (*DedicatedServerJob, error) {
 	result := &DedicatedServerJob{}
 	path := dsa.getPath("/servers/" + serverId + "/expireActiveJob")
-	if err := doRequest(ctx, http.MethodPost, path, "", result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodPost, path, "", result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -655,7 +657,7 @@ func (dsa DedicatedServerApi) ExpireActiveJob(ctx context.Context, serverId stri
 func (dsa DedicatedServerApi) LaunchHardwareScan(ctx context.Context, serverId string, payload map[string]interface{}) (*DedicatedServerJob, error) {
 	result := &DedicatedServerJob{}
 	path := dsa.getPath("/servers/" + serverId + "/hardwareScan")
-	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -664,7 +666,7 @@ func (dsa DedicatedServerApi) LaunchHardwareScan(ctx context.Context, serverId s
 func (dsa DedicatedServerApi) LaunchInstallation(ctx context.Context, serverId string, payload map[string]interface{}) (*DedicatedServerJob, error) {
 	result := &DedicatedServerJob{}
 	path := dsa.getPath("/servers/" + serverId + "/install")
-	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -673,7 +675,7 @@ func (dsa DedicatedServerApi) LaunchInstallation(ctx context.Context, serverId s
 func (dsa DedicatedServerApi) LaunchIpmiRest(ctx context.Context, serverId string, payload map[string]interface{}) (*DedicatedServerJob, error) {
 	result := &DedicatedServerJob{}
 	path := dsa.getPath("/servers/" + serverId + "/ipmiRest")
-	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -700,7 +702,7 @@ func (dsa DedicatedServerApi) ListJobs(ctx context.Context, serverId string, arg
 	result := &DedicatedServerJobs{}
 	path := dsa.getPath("/servers/" + serverId + "/jobs")
 	query := v.Encode()
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -709,7 +711,7 @@ func (dsa DedicatedServerApi) ListJobs(ctx context.Context, serverId string, arg
 func (dsa DedicatedServerApi) GetJob(ctx context.Context, serverId, jobId string) (*DedicatedServerJob, error) {
 	result := &DedicatedServerJob{}
 	path := dsa.getPath("/servers/" + serverId + "/jobs/" + jobId)
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -718,7 +720,7 @@ func (dsa DedicatedServerApi) GetJob(ctx context.Context, serverId, jobId string
 func (dsa DedicatedServerApi) LaunchRescueMode(ctx context.Context, serverId string, payload map[string]interface{}) (*DedicatedServerJob, error) {
 	result := &DedicatedServerJob{}
 	path := dsa.getPath("/servers/" + serverId + "/rescueMode")
-	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -736,7 +738,7 @@ func (dsa DedicatedServerApi) ListCredentials(ctx context.Context, serverId stri
 	result := &Credentials{}
 	path := dsa.getPath("/servers/" + serverId + "/credentials")
 	query := v.Encode()
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -749,7 +751,7 @@ func (dsa DedicatedServerApi) CreateCredential(ctx context.Context, serverId, cr
 	payload["username"] = username
 	payload["password"] = password
 	path := dsa.getPath("/servers/" + serverId + "/credentials")
-	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -767,7 +769,7 @@ func (dsa DedicatedServerApi) ListCredentialsByType(ctx context.Context, serverI
 	result := &Credentials{}
 	path := dsa.getPath("/servers/" + serverId + "/credentials/" + credentialType)
 	query := v.Encode()
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -776,7 +778,7 @@ func (dsa DedicatedServerApi) ListCredentialsByType(ctx context.Context, serverI
 func (dsa DedicatedServerApi) GetCredential(ctx context.Context, serverId, credentialType, username string) (*Credential, error) {
 	result := &Credential{}
 	path := dsa.getPath("/servers/" + serverId + "/credentials/" + credentialType + "/" + username)
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -784,14 +786,14 @@ func (dsa DedicatedServerApi) GetCredential(ctx context.Context, serverId, crede
 
 func (dsa DedicatedServerApi) DeleteCredential(ctx context.Context, serverId, credentialType, username string) error {
 	path := dsa.getPath("/servers/" + serverId + "/credentials/" + credentialType + "/" + username)
-	return doRequest(ctx, http.MethodDelete, path, "")
+	return getClient(dsa.Client).doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (dsa DedicatedServerApi) UpdateCredential(ctx context.Context, serverId, credentialType, username, password string) (*Credential, error) {
 	result := &Credential{}
 	payload := map[string]string{"password": password}
 	path := dsa.getPath("/servers/" + serverId + "/credentials/" + credentialType + "/" + username)
-	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -815,7 +817,7 @@ func (dsa DedicatedServerApi) GetDataTrafficMetrics(ctx context.Context, serverI
 	path := dsa.getPath("/servers/" + serverId + "/metrics/datatraffic")
 	query := v.Encode()
 	result := &DataTrafficMetricsV1{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -839,7 +841,7 @@ func (dsa DedicatedServerApi) GetBandWidthMetrics(ctx context.Context, serverId 
 	path := dsa.getPath("/servers/" + serverId + "/metrics/bandwidth")
 	query := v.Encode()
 	result := &BandWidthMetrics{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -857,7 +859,7 @@ func (dsa DedicatedServerApi) ListBandWidthNotificationSettings(ctx context.Cont
 	result := &BandWidthNotificationSettings{}
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/bandwidth")
 	query := v.Encode()
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -872,7 +874,7 @@ func (dsa DedicatedServerApi) CreateBandWidthNotificationSetting(ctx context.Con
 	}
 	result := &NotificationSetting{}
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/bandwidth")
-	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -880,13 +882,13 @@ func (dsa DedicatedServerApi) CreateBandWidthNotificationSetting(ctx context.Con
 
 func (dsa DedicatedServerApi) DeleteBandWidthNotificationSetting(ctx context.Context, serverId, notificationId string) error {
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/bandwidth/" + notificationId)
-	return doRequest(ctx, http.MethodDelete, path, "")
+	return getClient(dsa.Client).doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (dsa DedicatedServerApi) GetBandWidthNotificationSetting(ctx context.Context, serverId, notificationId string) (*NotificationSetting, error) {
 	result := &NotificationSetting{}
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/bandwidth/" + notificationId)
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -895,7 +897,7 @@ func (dsa DedicatedServerApi) GetBandWidthNotificationSetting(ctx context.Contex
 func (dsa DedicatedServerApi) UpdateBandWidthNotificationSetting(ctx context.Context, serverId, notificationSettingId string, payload map[string]string) (*NotificationSetting, error) {
 	result := &NotificationSetting{}
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/bandwidth/" + notificationSettingId)
-	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -913,7 +915,7 @@ func (dsa DedicatedServerApi) ListDataTrafficNotificationSettings(ctx context.Co
 	result := &DataTrafficNotificationSettings{}
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/datatraffic")
 	query := v.Encode()
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -927,7 +929,7 @@ func (dsa DedicatedServerApi) CreateDataTrafficNotificationSetting(ctx context.C
 	}
 	result := &NotificationSetting{}
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/datatraffic")
-	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -935,13 +937,13 @@ func (dsa DedicatedServerApi) CreateDataTrafficNotificationSetting(ctx context.C
 
 func (dsa DedicatedServerApi) DeleteDataTrafficNotificationSetting(ctx context.Context, serverId, notificationId string) error {
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/datatraffic/" + notificationId)
-	return doRequest(ctx, http.MethodDelete, path, "")
+	return getClient(dsa.Client).doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (dsa DedicatedServerApi) GetDataTrafficNotificationSetting(ctx context.Context, serverId, notificationId string) (*NotificationSetting, error) {
 	result := &NotificationSetting{}
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/datatraffic/" + notificationId)
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -950,7 +952,7 @@ func (dsa DedicatedServerApi) GetDataTrafficNotificationSetting(ctx context.Cont
 func (dsa DedicatedServerApi) UpdateDataTrafficNotificationSetting(ctx context.Context, serverId, notificationSettingId string, payload map[string]string) (*NotificationSetting, error) {
 	result := &NotificationSetting{}
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/datatraffic/" + notificationSettingId)
-	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -959,7 +961,7 @@ func (dsa DedicatedServerApi) UpdateDataTrafficNotificationSetting(ctx context.C
 func (dsa DedicatedServerApi) GetDdosNotificationSetting(ctx context.Context, serverId string) (*DdosNotificationSetting, error) {
 	result := &DdosNotificationSetting{}
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/ddos")
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -967,7 +969,7 @@ func (dsa DedicatedServerApi) GetDdosNotificationSetting(ctx context.Context, se
 
 func (dsa DedicatedServerApi) UpdateDdosNotificationSetting(ctx context.Context, serverId string, payload map[string]string) error {
 	path := dsa.getPath("/servers/" + serverId + "/notificationSettings/ddos/")
-	if err := doRequest(ctx, http.MethodPut, path, "", nil, payload); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodPut, path, "", nil, payload); err != nil {
 		return err
 	}
 	return nil
@@ -975,13 +977,13 @@ func (dsa DedicatedServerApi) UpdateDdosNotificationSetting(ctx context.Context,
 
 func (dsa DedicatedServerApi) PowerCycleServer(ctx context.Context, serverId string) error {
 	path := dsa.getPath("/servers/" + serverId + "/powerCycle")
-	return doRequest(ctx, http.MethodPost, path, "")
+	return getClient(dsa.Client).doRequest(ctx, http.MethodPost, path, "")
 }
 
 func (dsa DedicatedServerApi) GetPowerStatus(ctx context.Context, serverId string) (*PowerStatus, error) {
 	result := &PowerStatus{}
 	path := dsa.getPath("/servers/" + serverId + "/powerInfo")
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -989,12 +991,12 @@ func (dsa DedicatedServerApi) GetPowerStatus(ctx context.Context, serverId strin
 
 func (dsa DedicatedServerApi) PowerOffServer(ctx context.Context, serverId string) error {
 	path := dsa.getPath("/servers/" + serverId + "/powerOff")
-	return doRequest(ctx, http.MethodPost, path, "")
+	return getClient(dsa.Client).doRequest(ctx, http.MethodPost, path, "")
 }
 
 func (dsa DedicatedServerApi) PowerOnServer(ctx context.Context, serverId string) error {
 	path := dsa.getPath("/servers/" + serverId + "/powerOn")
-	return doRequest(ctx, http.MethodPost, path, "")
+	return getClient(dsa.Client).doRequest(ctx, http.MethodPost, path, "")
 }
 
 func (dsa DedicatedServerApi) ListOperatingSystems(ctx context.Context, args ...interface{}) (*DedicatedServerOperatingSystems, error) {
@@ -1012,7 +1014,7 @@ func (dsa DedicatedServerApi) ListOperatingSystems(ctx context.Context, args ...
 	result := &DedicatedServerOperatingSystems{}
 	path := dsa.getPath("/operatingSystems")
 	query := v.Encode()
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -1024,7 +1026,7 @@ func (dsa DedicatedServerApi) GetOperatingSystem(ctx context.Context, operatingS
 	result := &DedicatedServerOperatingSystem{}
 	path := dsa.getPath("/operatingSystems/" + operatingSystemId)
 	query := v.Encode()
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -1045,7 +1047,7 @@ func (dsa DedicatedServerApi) ListControlPanels(ctx context.Context, args ...int
 	result := &DedicatedServerControlPanels{}
 	path := dsa.getPath("/controlPanels")
 	query := v.Encode()
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -1063,7 +1065,7 @@ func (dsa DedicatedServerApi) ListRescueImages(ctx context.Context, args ...inte
 	result := &DedicatedServerRescueImages{}
 	path := dsa.getPath("/rescueImages")
 	query := v.Encode()
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(dsa.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return result, err
 	}
 	return result, nil

--- a/floating_ip.go
+++ b/floating_ip.go
@@ -11,7 +11,9 @@ import (
 
 const FLOATING_IP_API_VERSION = "v2"
 
-type FloatingIpApi struct{}
+type FloatingIpApi struct {
+	Client *LeasewebClient
+}
 
 type FloatingIpRange struct {
 	Id         string `json:"id"`
@@ -73,7 +75,7 @@ func (fia FloatingIpApi) ListRanges(ctx context.Context, args ...interface{}) (*
 	path := fia.getPath("/ranges")
 	query := v.Encode()
 	result := &FloatingIpRanges{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(fia.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -82,7 +84,7 @@ func (fia FloatingIpApi) ListRanges(ctx context.Context, args ...interface{}) (*
 func (fia FloatingIpApi) GetRange(ctx context.Context, rangeId string) (*FloatingIpRange, error) {
 	path := fia.getPath("/ranges/" + rangeId)
 	result := &FloatingIpRange{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(fia.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -111,7 +113,7 @@ func (fia FloatingIpApi) ListRangeDefinitions(ctx context.Context, rangeId strin
 	path := fia.getPath("/ranges/" + rangeId + "/floatingIpDefinitions")
 	query := v.Encode()
 	result := &FloatingIpDefinitions{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(fia.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -121,7 +123,7 @@ func (fia FloatingIpApi) CreateRangeDefinition(ctx context.Context, rangeId stri
 	payload := map[string]string{"floatingIp": floatingIp, "anchorIp": anchorIp}
 	path := fia.getPath("/ranges/" + rangeId + "/floatingIpDefinitions")
 	result := &FloatingIpDefinition{}
-	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
+	if err := getClient(fia.Client).doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -130,7 +132,7 @@ func (fia FloatingIpApi) CreateRangeDefinition(ctx context.Context, rangeId stri
 func (fia FloatingIpApi) GetRangeDefinition(ctx context.Context, rangeId string, floatingIpDefinitionId string) (*FloatingIpDefinition, error) {
 	path := fia.getPath("/ranges/" + rangeId + "/floatingIpDefinitions/" + floatingIpDefinitionId)
 	result := &FloatingIpDefinition{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(fia.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -140,7 +142,7 @@ func (fia FloatingIpApi) UpdateRangeDefinition(ctx context.Context, rangeId stri
 	payload := map[string]string{"anchorIp": anchorIp}
 	path := fia.getPath("/ranges/" + rangeId + "/floatingIpDefinitions/" + floatingIpDefinitionId)
 	result := &FloatingIpDefinition{}
-	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
+	if err := getClient(fia.Client).doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -149,7 +151,7 @@ func (fia FloatingIpApi) UpdateRangeDefinition(ctx context.Context, rangeId stri
 func (fia FloatingIpApi) RemoveRangeDefinition(ctx context.Context, rangeId string, floatingIpDefinitionId string) (*FloatingIpDefinition, error) {
 	path := fia.getPath("/ranges/" + rangeId + "/floatingIpDefinitions/" + floatingIpDefinitionId)
 	result := &FloatingIpDefinition{}
-	if err := doRequest(ctx, http.MethodDelete, path, "", result); err != nil {
+	if err := getClient(fia.Client).doRequest(ctx, http.MethodDelete, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/hosting.go
+++ b/hosting.go
@@ -10,7 +10,9 @@ import (
 
 const HOSTING_API_VERSION = "v2"
 
-type HostingApi struct{}
+type HostingApi struct {
+	Client *LeasewebClient
+}
 
 type HostingDomains struct {
 	Domains  []HostingDomain `json:"domains"`
@@ -162,7 +164,7 @@ func (ha HostingApi) ListDomains(ctx context.Context, args ...interface{}) (*Hos
 	path := ha.getPath("/domains")
 	query := v.Encode()
 	result := &HostingDomains{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(ha.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -171,7 +173,7 @@ func (ha HostingApi) ListDomains(ctx context.Context, args ...interface{}) (*Hos
 func (ha HostingApi) GetDomain(ctx context.Context, domainName string) (*HostingDomain, error) {
 	path := ha.getPath("/domains/" + domainName)
 	result := &HostingDomain{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(ha.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -180,7 +182,7 @@ func (ha HostingApi) GetDomain(ctx context.Context, domainName string) (*Hosting
 func (ha HostingApi) GetAvailability(ctx context.Context, domainName string) (*HostingDomainAvailability, error) {
 	path := ha.getPath("/domains/" + domainName + "/available")
 	result := &HostingDomainAvailability{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(ha.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -198,7 +200,7 @@ func (ha HostingApi) ListNameservers(ctx context.Context, domainName string, arg
 	path := ha.getPath("/domains/" + domainName + "/nameservers")
 	query := v.Encode()
 	result := &HostingNameservers{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(ha.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -209,7 +211,7 @@ func (ha HostingApi) UpdateNameservers(ctx context.Context, domainName string, n
 	payload["nameservers"] = nameservers
 	path := ha.getPath("/domains/" + domainName + "/nameservers")
 	result := &HostingNameservers{}
-	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
+	if err := getClient(ha.Client).doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -218,7 +220,7 @@ func (ha HostingApi) UpdateNameservers(ctx context.Context, domainName string, n
 func (ha HostingApi) GetDnsSecurity(ctx context.Context, domainName string) (*HostingDnsSecurity, error) {
 	path := ha.getPath("/domains/" + domainName + "/dnssec")
 	result := &HostingDnsSecurity{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(ha.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -227,7 +229,7 @@ func (ha HostingApi) GetDnsSecurity(ctx context.Context, domainName string) (*Ho
 func (ha HostingApi) UpdateDnsSecurity(ctx context.Context, domainName string, payload map[string]interface{}) (*HostingInfoMessageResponse, error) {
 	path := ha.getPath("/domains/" + domainName + "/dnssec")
 	result := &HostingInfoMessageResponse{}
-	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
+	if err := getClient(ha.Client).doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -245,7 +247,7 @@ func (ha HostingApi) ListResourceRecordSets(ctx context.Context, domainName stri
 	path := ha.getPath("/domains/" + domainName + "/resourceRecordSets")
 	query := v.Encode()
 	result := &HostingResourceRecordSets{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(ha.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -254,7 +256,7 @@ func (ha HostingApi) ListResourceRecordSets(ctx context.Context, domainName stri
 func (ha HostingApi) CreateResourceRecordSet(ctx context.Context, domainName string, payload map[string]interface{}) (*HostingResourceRecordSet, error) {
 	path := ha.getPath("/domains/" + domainName + "/resourceRecordSets")
 	result := &HostingResourceRecordSet{}
-	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
+	if err := getClient(ha.Client).doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -262,13 +264,13 @@ func (ha HostingApi) CreateResourceRecordSet(ctx context.Context, domainName str
 
 func (ha HostingApi) DeleteResourceRecordSets(ctx context.Context, domainName string) error {
 	path := ha.getPath("/domains/" + domainName + "/resourceRecordSets")
-	return doRequest(ctx, http.MethodDelete, path, "")
+	return getClient(ha.Client).doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (ha HostingApi) GetResourceRecordSet(ctx context.Context, domainName, name, recordType string) (*HostingResourceRecordSet, error) {
 	path := ha.getPath("/domains/" + domainName + "/resourceRecordSets/" + name + "/" + recordType)
 	result := &HostingResourceRecordSet{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(ha.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -280,7 +282,7 @@ func (ha HostingApi) UpdateResourceRecordSet(ctx context.Context, domainName, na
 	payload := make(map[string]interface{})
 	payload["content"] = content
 	payload["ttl"] = ttl
-	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
+	if err := getClient(ha.Client).doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -288,7 +290,7 @@ func (ha HostingApi) UpdateResourceRecordSet(ctx context.Context, domainName, na
 
 func (ha HostingApi) DeleteResourceRecordSet(ctx context.Context, domainName, name, recordType string) error {
 	path := ha.getPath("/domains/" + domainName + "/resourceRecordSets/" + name + "/" + recordType)
-	return doRequest(ctx, http.MethodDelete, path, "")
+	return getClient(ha.Client).doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (ha HostingApi) ValidateResourceRecordSet(ctx context.Context, domainName, name, recordType string, content []string, ttl int) (*HostingInfoMessageResponse, error) {
@@ -299,7 +301,7 @@ func (ha HostingApi) ValidateResourceRecordSet(ctx context.Context, domainName, 
 	payload["type"] = recordType
 	payload["content"] = content
 	payload["ttl"] = ttl
-	if err := doRequest(ctx, http.MethodPost, path, "", result); err != nil {
+	if err := getClient(ha.Client).doRequest(ctx, http.MethodPost, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -308,7 +310,7 @@ func (ha HostingApi) ValidateResourceRecordSet(ctx context.Context, domainName, 
 func (ha HostingApi) ListCatchAll(ctx context.Context, domainName string) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/catchAll")
 	result := &HostingEmail{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(ha.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -317,7 +319,7 @@ func (ha HostingApi) ListCatchAll(ctx context.Context, domainName string) (*Host
 func (ha HostingApi) UpdateCatchAll(ctx context.Context, domainName string, payload map[string]interface{}) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/catchAll")
 	result := &HostingEmail{}
-	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
+	if err := getClient(ha.Client).doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -329,7 +331,7 @@ func (ha HostingApi) CreateCatchAll(ctx context.Context, domainName string, payl
 
 func (ha HostingApi) DeleteCatchAll(ctx context.Context, domainName string) error {
 	path := ha.getPath("/domains/" + domainName + "/catchAll")
-	return doRequest(ctx, http.MethodDelete, path, "")
+	return getClient(ha.Client).doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (ha HostingApi) ListEmailAliases(ctx context.Context, domainName string, args ...interface{}) (*HostingEmailAliases, error) {
@@ -344,7 +346,7 @@ func (ha HostingApi) ListEmailAliases(ctx context.Context, domainName string, ar
 	path := ha.getPath("/domains/" + domainName + "/emailAliases")
 	query := v.Encode()
 	result := &HostingEmailAliases{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(ha.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -353,7 +355,7 @@ func (ha HostingApi) ListEmailAliases(ctx context.Context, domainName string, ar
 func (ha HostingApi) CreateEmailAlias(ctx context.Context, domainName string, payload map[string]interface{}) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/emailAliases")
 	result := &HostingEmail{}
-	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
+	if err := getClient(ha.Client).doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -362,7 +364,7 @@ func (ha HostingApi) CreateEmailAlias(ctx context.Context, domainName string, pa
 func (ha HostingApi) GetEmailAlias(ctx context.Context, domainName, source, destination string) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/emailAliases/" + source + "/" + destination)
 	result := &HostingEmail{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(ha.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -371,7 +373,7 @@ func (ha HostingApi) GetEmailAlias(ctx context.Context, domainName, source, dest
 func (ha HostingApi) UpdateEmailAlias(ctx context.Context, domainName, source, destination string, payload map[string]bool) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/emailAliases/" + source + "/" + destination)
 	result := &HostingEmail{}
-	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
+	if err := getClient(ha.Client).doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -379,7 +381,7 @@ func (ha HostingApi) UpdateEmailAlias(ctx context.Context, domainName, source, d
 
 func (ha HostingApi) DeleteEmailAlias(ctx context.Context, domainName, source, destination string) error {
 	path := ha.getPath("/domains/" + domainName + "/emailAliases/" + source + "/" + destination)
-	return doRequest(ctx, http.MethodDelete, path, "")
+	return getClient(ha.Client).doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (ha HostingApi) ListDomainForwards(ctx context.Context, domainName string, args ...interface{}) (*HostingEmailForwards, error) {
@@ -394,7 +396,7 @@ func (ha HostingApi) ListDomainForwards(ctx context.Context, domainName string, 
 	path := ha.getPath("/domains/" + domainName + "/forwards")
 	query := v.Encode()
 	result := &HostingEmailForwards{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(ha.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -412,7 +414,7 @@ func (ha HostingApi) ListMailBoxes(ctx context.Context, domainName string, args 
 	path := ha.getPath("/domains/" + domainName + "/mailboxes")
 	query := v.Encode()
 	result := &HostingEmailMailboxes{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(ha.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -421,7 +423,7 @@ func (ha HostingApi) ListMailBoxes(ctx context.Context, domainName string, args 
 func (ha HostingApi) CreateMailBox(ctx context.Context, domainName string, payload map[string]interface{}) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes")
 	result := &HostingEmail{}
-	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
+	if err := getClient(ha.Client).doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -430,7 +432,7 @@ func (ha HostingApi) CreateMailBox(ctx context.Context, domainName string, paylo
 func (ha HostingApi) GetMailBox(ctx context.Context, domainName, emailAddress string) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress)
 	result := &HostingEmail{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(ha.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -439,7 +441,7 @@ func (ha HostingApi) GetMailBox(ctx context.Context, domainName, emailAddress st
 func (ha HostingApi) UpdateMailBox(ctx context.Context, domainName, emailAddress string, payload map[string]interface{}) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress)
 	result := &HostingEmail{}
-	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
+	if err := getClient(ha.Client).doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -447,13 +449,13 @@ func (ha HostingApi) UpdateMailBox(ctx context.Context, domainName, emailAddress
 
 func (ha HostingApi) DeleteMailBox(ctx context.Context, domainName, emailAddress string) error {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress)
-	return doRequest(ctx, http.MethodDelete, path, "")
+	return getClient(ha.Client).doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (ha HostingApi) GetAutoResponder(ctx context.Context, domainName, emailAddress string) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress + "/autoResponder")
 	result := &HostingEmail{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(ha.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -462,7 +464,7 @@ func (ha HostingApi) GetAutoResponder(ctx context.Context, domainName, emailAddr
 func (ha HostingApi) UpdateAutoResponder(ctx context.Context, domainName, emailAddress string, payload map[string]interface{}) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress + "/autoResponder")
 	result := &HostingEmail{}
-	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
+	if err := getClient(ha.Client).doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -474,7 +476,7 @@ func (ha HostingApi) CreateAutoResponder(ctx context.Context, domainName, emailA
 
 func (ha HostingApi) DeleteAutoResponder(ctx context.Context, domainName, emailAddress string) error {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress + "/autoResponder")
-	return doRequest(ctx, http.MethodDelete, path, "")
+	return getClient(ha.Client).doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (ha HostingApi) ListForwards(ctx context.Context, domainName, emailAddress string, args ...interface{}) (*HostingEmailForwards, error) {
@@ -489,7 +491,7 @@ func (ha HostingApi) ListForwards(ctx context.Context, domainName, emailAddress 
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress + "/forwards")
 	query := v.Encode()
 	result := &HostingEmailForwards{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(ha.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -498,7 +500,7 @@ func (ha HostingApi) ListForwards(ctx context.Context, domainName, emailAddress 
 func (ha HostingApi) CreateForward(ctx context.Context, domainName, emailAddress string, payload map[string]interface{}) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress + "/forwards")
 	result := &HostingEmail{}
-	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
+	if err := getClient(ha.Client).doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -507,7 +509,7 @@ func (ha HostingApi) CreateForward(ctx context.Context, domainName, emailAddress
 func (ha HostingApi) GetForward(ctx context.Context, domainName, emailAddress, destination string) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress + "/forwards/" + destination)
 	result := &HostingEmail{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(ha.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -516,7 +518,7 @@ func (ha HostingApi) GetForward(ctx context.Context, domainName, emailAddress, d
 func (ha HostingApi) UpdateForward(ctx context.Context, domainName, emailAddress, destination string, payload map[string]bool) (*HostingEmail, error) {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress + "/forwards/" + destination)
 	result := &HostingEmail{}
-	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
+	if err := getClient(ha.Client).doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -524,5 +526,5 @@ func (ha HostingApi) UpdateForward(ctx context.Context, domainName, emailAddress
 
 func (ha HostingApi) DeleteForward(ctx context.Context, domainName, emailAddress, destination string) error {
 	path := ha.getPath("/domains/" + domainName + "/mailboxes/" + emailAddress + "/forwards/" + destination)
-	return doRequest(ctx, http.MethodDelete, path, "")
+	return getClient(ha.Client).doRequest(ctx, http.MethodDelete, path, "")
 }

--- a/invoice.go
+++ b/invoice.go
@@ -10,7 +10,9 @@ import (
 
 const INVOICE_API_VERSION = "v1"
 
-type InvoiceApi struct{}
+type InvoiceApi struct {
+	Client *LeasewebClient
+}
 
 type Invoice struct {
 	Currency                string          `json:"currency"`
@@ -86,7 +88,7 @@ func (ia InvoiceApi) List(ctx context.Context, args ...int) (*Invoices, error) {
 	path := ia.getPath("/invoices")
 	query := v.Encode()
 	result := &Invoices{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(ia.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -104,7 +106,7 @@ func (ia InvoiceApi) ListProForma(ctx context.Context, args ...int) (*InvoicePro
 	path := ia.getPath("/invoices/proforma")
 	query := v.Encode()
 	result := &InvoiceProForma{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(ia.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -113,7 +115,7 @@ func (ia InvoiceApi) ListProForma(ctx context.Context, args ...int) (*InvoicePro
 func (ia InvoiceApi) Get(ctx context.Context, invoiceId string) (*Invoice, error) {
 	path := ia.getPath("/invoices/" + invoiceId)
 	result := &Invoice{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(ia.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/ip_management.go
+++ b/ip_management.go
@@ -9,7 +9,9 @@ import (
 
 const IP_MANAGEMENT_API_VERSION = "v2"
 
-type IpManagementApi struct{}
+type IpManagementApi struct {
+	Client *LeasewebClient
+}
 
 func (ima IpManagementApi) getPath(endpoint string) string {
 	return "/ipMgmt/" + IP_MANAGEMENT_API_VERSION + endpoint
@@ -25,7 +27,7 @@ func (ima IpManagementApi) List(ctx context.Context, params ...map[string]interf
 	path := ima.getPath("/ips")
 	query := v.Encode()
 	result := &Ips{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(ima.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -34,7 +36,7 @@ func (ima IpManagementApi) List(ctx context.Context, params ...map[string]interf
 func (ima IpManagementApi) Get(ctx context.Context, ip string) (*Ip, error) {
 	path := ima.getPath("/ips/" + ip)
 	result := &Ip{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(ima.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -44,7 +46,7 @@ func (ima IpManagementApi) Update(ctx context.Context, ip, reverseLookup string)
 	payload := map[string]string{"reverseLookup": reverseLookup}
 	path := ima.getPath("/ips/" + ip)
 	result := &Ip{}
-	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
+	if err := getClient(ima.Client).doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -59,7 +61,7 @@ func (ima IpManagementApi) NullRouteAnIp(ctx context.Context, ip string, params 
 	}
 	path := ima.getPath("/ips/" + ip + "/nullRoute")
 	result := &NullRoute{}
-	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
+	if err := getClient(ima.Client).doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -67,7 +69,7 @@ func (ima IpManagementApi) NullRouteAnIp(ctx context.Context, ip string, params 
 
 func (ima IpManagementApi) RemoveNullRouteAnIp(ctx context.Context, ip string) error {
 	path := ima.getPath("/ips/" + ip + "/nullRoute")
-	return doRequest(ctx, http.MethodDelete, path, "")
+	return getClient(ima.Client).doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (ima IpManagementApi) ListNullRoutes(ctx context.Context, params ...map[string]interface{}) (*NullRoutes, error) {
@@ -80,7 +82,7 @@ func (ima IpManagementApi) ListNullRoutes(ctx context.Context, params ...map[str
 	path := ima.getPath("/nullRoutes")
 	query := v.Encode()
 	result := &NullRoutes{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(ima.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -89,7 +91,7 @@ func (ima IpManagementApi) ListNullRoutes(ctx context.Context, params ...map[str
 func (ima IpManagementApi) GetNullRoute(ctx context.Context, id string) (*NullRoute, error) {
 	path := ima.getPath("/nullRoutes/" + id)
 	result := &NullRoute{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(ima.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -104,7 +106,7 @@ func (ima IpManagementApi) UpdateNullRoute(ctx context.Context, id string, param
 	}
 	path := ima.getPath("/nullRoutes/" + id)
 	result := &NullRoute{}
-	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
+	if err := getClient(ima.Client).doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/private_cloud.go
+++ b/private_cloud.go
@@ -9,7 +9,9 @@ import (
 
 const PRIVATE_CLOUD_API_VERSION = "v2"
 
-type PrivateCloudApi struct{}
+type PrivateCloudApi struct {
+	Client *LeasewebClient
+}
 
 type PrivateClouds struct {
 	PrivateClouds []PrivateCloud `json:"privateClouds"`
@@ -71,7 +73,7 @@ func (pca PrivateCloudApi) List(ctx context.Context, args ...interface{}) (*Priv
 	path := pca.getPath("/privateClouds")
 	query := v.Encode()
 	result := &PrivateClouds{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(pca.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -80,7 +82,7 @@ func (pca PrivateCloudApi) List(ctx context.Context, args ...interface{}) (*Priv
 func (pca PrivateCloudApi) Get(ctx context.Context, privateCloudId string) (*PrivateCloud, error) {
 	path := pca.getPath("/privateClouds/" + privateCloudId)
 	result := &PrivateCloud{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(pca.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -98,7 +100,7 @@ func (pca PrivateCloudApi) ListCredentials(ctx context.Context, privateCloudId s
 	path := pca.getPath("/privateClouds/" + privateCloudId + "/credentials/" + credentialType)
 	query := v.Encode()
 	result := &Credentials{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(pca.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -107,7 +109,7 @@ func (pca PrivateCloudApi) ListCredentials(ctx context.Context, privateCloudId s
 func (pca PrivateCloudApi) GetCredential(ctx context.Context, privateCloudId string, credentialType string, username string) (*Credential, error) {
 	path := pca.getPath("/privateClouds/" + privateCloudId + "/credentials/" + credentialType + "/" + username)
 	result := &Credential{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(pca.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -131,7 +133,7 @@ func (pca PrivateCloudApi) GetDataTrafficMetrics(ctx context.Context, privateClo
 	path := pca.getPath("/privateClouds/" + privateCloudId + "/metrics/datatraffic")
 	query := v.Encode()
 	result := &DataTrafficMetricsV2{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(pca.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -155,7 +157,7 @@ func (pca PrivateCloudApi) GetBandWidthMetrics(ctx context.Context, privateCloud
 	path := pca.getPath("/privateClouds/" + privateCloudId + "/metrics/bandwidth")
 	query := v.Encode()
 	result := &BandWidthMetrics{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(pca.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -178,7 +180,7 @@ func (pca PrivateCloudApi) GetCpuMetrics(ctx context.Context, privateCloudId str
 	path := pca.getPath("/privateClouds/" + privateCloudId + "/metrics/cpu")
 	query := v.Encode()
 	result := &PrivateCloudCpuMetrics{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(pca.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -201,7 +203,7 @@ func (pca PrivateCloudApi) GetMemoryMetrics(ctx context.Context, privateCloudId 
 	path := pca.getPath("/privateClouds/" + privateCloudId + "/metrics/memory")
 	query := v.Encode()
 	result := &PrivateCloudMemoryMetrics{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(pca.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -224,7 +226,7 @@ func (pca PrivateCloudApi) GetStorageMetrics(ctx context.Context, privateCloudId
 	path := pca.getPath("/privateClouds/" + privateCloudId + "/metrics/storage")
 	query := v.Encode()
 	result := &PrivateCloudStorageMetrics{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(pca.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/private_networking.go
+++ b/private_networking.go
@@ -9,7 +9,9 @@ import (
 
 const PRIVATE_NETWORKING_API_VERSION = "v2"
 
-type PrivateNetworkingApi struct{}
+type PrivateNetworkingApi struct {
+	Client *LeasewebClient
+}
 
 type PrivateNetworks struct {
 	PrivateNetworks []PrivateNetwork `json:"privateNetworks"`
@@ -43,7 +45,7 @@ func (pna PrivateNetworkingApi) List(ctx context.Context, args ...int) (*Private
 	path := pna.getPath("/privateNetworks")
 	query := v.Encode()
 	result := &PrivateNetworks{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(pna.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -55,7 +57,7 @@ func (pna PrivateNetworkingApi) Create(ctx context.Context, name string) (*Priva
 	}
 	path := pna.getPath("/privateNetworks")
 	result := &PrivateNetwork{}
-	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
+	if err := getClient(pna.Client).doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -64,7 +66,7 @@ func (pna PrivateNetworkingApi) Create(ctx context.Context, name string) (*Priva
 func (pna PrivateNetworkingApi) Get(ctx context.Context, id string) (*PrivateNetwork, error) {
 	path := pna.getPath("/privateNetworks/" + id)
 	result := &PrivateNetwork{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(pna.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -76,7 +78,7 @@ func (pna PrivateNetworkingApi) Update(ctx context.Context, id, name string) (*P
 	}
 	path := pna.getPath("/privateNetworks")
 	result := &PrivateNetwork{}
-	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
+	if err := getClient(pna.Client).doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -84,7 +86,7 @@ func (pna PrivateNetworkingApi) Update(ctx context.Context, id, name string) (*P
 
 func (pna PrivateNetworkingApi) Delete(ctx context.Context, id string) error {
 	path := pna.getPath("/privateNetworks/" + id)
-	return doRequest(ctx, http.MethodDelete, path, "")
+	return getClient(pna.Client).doRequest(ctx, http.MethodDelete, path, "")
 }
 
 func (pna PrivateNetworkingApi) ListDhcpReservations(ctx context.Context, id string, args ...int) (*PrivateNetworkingDhcpReservations, error) {
@@ -99,7 +101,7 @@ func (pna PrivateNetworkingApi) ListDhcpReservations(ctx context.Context, id str
 	path := pna.getPath("/privateNetworks/" + id + "/reservations")
 	query := v.Encode()
 	result := &PrivateNetworkingDhcpReservations{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(pna.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -113,7 +115,7 @@ func (pna PrivateNetworkingApi) CreateDhcpReservation(ctx context.Context, id, i
 	}
 	path := pna.getPath("/privateNetworks/" + id + "/reservations")
 	result := &PrivateNetworkingDhcpReservation{}
-	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
+	if err := getClient(pna.Client).doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -121,5 +123,5 @@ func (pna PrivateNetworkingApi) CreateDhcpReservation(ctx context.Context, id, i
 
 func (pna PrivateNetworkingApi) DeleteDhcpReservation(ctx context.Context, id, ip string) error {
 	path := pna.getPath("/privateNetworks/" + id + "/reservations/" + ip)
-	return doRequest(ctx, http.MethodDelete, path, "")
+	return getClient(pna.Client).doRequest(ctx, http.MethodDelete, path, "")
 }

--- a/remote_management.go
+++ b/remote_management.go
@@ -9,7 +9,9 @@ import (
 
 const REMOTE_MANAGEMENT_API_VERSION = "v2"
 
-type RemoteManagementApi struct{}
+type RemoteManagementApi struct {
+	Client *LeasewebClient
+}
 
 type RemoteManagementProfiles struct {
 	Metadata Metadata                  `json:"_metadata"`
@@ -29,7 +31,7 @@ func (rma RemoteManagementApi) getPath(endpoint string) string {
 func (rma RemoteManagementApi) ChangeCredentials(ctx context.Context, password string) error {
 	payload := map[string]string{password: password}
 	path := rma.getPath("/remoteManagement/changeCredentials")
-	return doRequest(ctx, http.MethodPost, path, "", nil, payload)
+	return getClient(rma.Client).doRequest(ctx, http.MethodPost, path, "", nil, payload)
 }
 
 func (rma RemoteManagementApi) ListProfiles(ctx context.Context, args ...int) (*RemoteManagementProfiles, error) {
@@ -44,7 +46,7 @@ func (rma RemoteManagementApi) ListProfiles(ctx context.Context, args ...int) (*
 	path := rma.getPath("/remoteManagement/profiles")
 	query := v.Encode()
 	result := &RemoteManagementProfiles{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(rma.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/services.go
+++ b/services.go
@@ -10,7 +10,9 @@ import (
 
 const SERVICES_API_VERSION = "v1"
 
-type ServicesApi struct{}
+type ServicesApi struct {
+	Client *LeasewebClient
+}
 
 type Services struct {
 	Services []Service `json:"services"`
@@ -65,7 +67,7 @@ func (sa ServicesApi) List(ctx context.Context, args ...int) (*Services, error) 
 	path := sa.getPath("/services")
 	query := v.Encode()
 	result := &Services{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(sa.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -74,7 +76,7 @@ func (sa ServicesApi) List(ctx context.Context, args ...int) (*Services, error) 
 func (sa ServicesApi) ListCancellationReasons(ctx context.Context) (*ServicesCancellationReasons, error) {
 	path := sa.getPath("/services/cancellationReasons")
 	result := &ServicesCancellationReasons{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(sa.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -83,7 +85,7 @@ func (sa ServicesApi) ListCancellationReasons(ctx context.Context) (*ServicesCan
 func (sa ServicesApi) Get(ctx context.Context, id string) (*Service, error) {
 	path := sa.getPath("/services/" + id)
 	result := &Service{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(sa.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -95,10 +97,10 @@ func (sa ServicesApi) Cancel(ctx context.Context, id, reason, reasonCode string)
 		"reasonCode": reasonCode,
 	}
 	path := sa.getPath("/services/" + id + "/cancel")
-	return doRequest(ctx, http.MethodPost, path, "", nil, payload)
+	return getClient(sa.Client).doRequest(ctx, http.MethodPost, path, "", nil, payload)
 }
 
 func (sa ServicesApi) Uncancel(ctx context.Context, id string) error {
 	path := sa.getPath("/services/" + id + "/uncancel")
-	return doRequest(ctx, http.MethodPost, path, "")
+	return getClient(sa.Client).doRequest(ctx, http.MethodPost, path, "")
 }

--- a/virtual_server.go
+++ b/virtual_server.go
@@ -9,7 +9,9 @@ import (
 
 const VIRTUAL_SERVER_API_VERSION = "v2"
 
-type VirtualServerApi struct{}
+type VirtualServerApi struct {
+	Client *LeasewebClient
+}
 
 type VirtualServers struct {
 	VirtualServers []VirtualServer `json:"virtualServers"`
@@ -72,7 +74,7 @@ func (vsa VirtualServerApi) List(ctx context.Context, args ...int) (*VirtualServ
 	path := vsa.getPath("/virtualServers")
 	query := v.Encode()
 	result := &VirtualServers{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(vsa.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -81,7 +83,7 @@ func (vsa VirtualServerApi) List(ctx context.Context, args ...int) (*VirtualServ
 func (vsa VirtualServerApi) Get(ctx context.Context, virtualServerId string) (*VirtualServer, error) {
 	path := vsa.getPath("/virtualServers/" + virtualServerId)
 	result := &VirtualServer{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(vsa.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -91,7 +93,7 @@ func (vsa VirtualServerApi) Update(ctx context.Context, virtualServerId, referen
 	payload := map[string]string{"reference": reference}
 	path := vsa.getPath("/virtualServers/" + virtualServerId)
 	result := &VirtualServer{}
-	if err := doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
+	if err := getClient(vsa.Client).doRequest(ctx, http.MethodPut, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -100,7 +102,7 @@ func (vsa VirtualServerApi) Update(ctx context.Context, virtualServerId, referen
 func (vsa VirtualServerApi) PowerOn(ctx context.Context, virtualServerId string) (*VirtualServerResult, error) {
 	path := vsa.getPath("/virtualServers/" + virtualServerId + "/powerOn")
 	result := &VirtualServerResult{}
-	if err := doRequest(ctx, http.MethodPost, path, "", result); err != nil {
+	if err := getClient(vsa.Client).doRequest(ctx, http.MethodPost, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -109,7 +111,7 @@ func (vsa VirtualServerApi) PowerOn(ctx context.Context, virtualServerId string)
 func (vsa VirtualServerApi) PowerOff(ctx context.Context, virtualServerId string) (*VirtualServerResult, error) {
 	path := vsa.getPath("/virtualServers/" + virtualServerId + "/powerOff")
 	result := &VirtualServerResult{}
-	if err := doRequest(ctx, http.MethodPost, path, "", result); err != nil {
+	if err := getClient(vsa.Client).doRequest(ctx, http.MethodPost, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -118,7 +120,7 @@ func (vsa VirtualServerApi) PowerOff(ctx context.Context, virtualServerId string
 func (vsa VirtualServerApi) Reboot(ctx context.Context, virtualServerId string) (*VirtualServerResult, error) {
 	path := vsa.getPath("/virtualServers/" + virtualServerId + "/reboot")
 	result := &VirtualServerResult{}
-	if err := doRequest(ctx, http.MethodPost, path, "", result); err != nil {
+	if err := getClient(vsa.Client).doRequest(ctx, http.MethodPost, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -128,7 +130,7 @@ func (vsa VirtualServerApi) Reinstall(ctx context.Context, virtualServerId, oper
 	payload := map[string]string{"operatingSystemId": operatingSystemId}
 	path := vsa.getPath("/virtualServers/" + virtualServerId + "/reinstall")
 	result := &VirtualServerResult{}
-	if err := doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
+	if err := getClient(vsa.Client).doRequest(ctx, http.MethodPost, path, "", result, payload); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -137,7 +139,7 @@ func (vsa VirtualServerApi) Reinstall(ctx context.Context, virtualServerId, oper
 func (vsa VirtualServerApi) UpdateCredential(ctx context.Context, virtualServerId, username, credentialType, password string) error {
 	payload := map[string]string{"username": username, "type": credentialType, "password": password}
 	path := vsa.getPath("/virtualServers/" + virtualServerId + "/credentials")
-	return doRequest(ctx, http.MethodPut, path, "", nil, payload)
+	return getClient(vsa.Client).doRequest(ctx, http.MethodPut, path, "", nil, payload)
 }
 
 func (vsa VirtualServerApi) ListCredentials(ctx context.Context, virtualServerId, credentialType string, args ...int) (*Credentials, error) {
@@ -152,7 +154,7 @@ func (vsa VirtualServerApi) ListCredentials(ctx context.Context, virtualServerId
 	path := vsa.getPath("/virtualServers/" + virtualServerId + "/credentials/" + credentialType)
 	query := v.Encode()
 	result := &Credentials{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(vsa.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -161,7 +163,7 @@ func (vsa VirtualServerApi) ListCredentials(ctx context.Context, virtualServerId
 func (vsa VirtualServerApi) GetCredential(ctx context.Context, virtualServerId, username, credentialType string) (*Credential, error) {
 	path := vsa.getPath("/virtualServers/" + virtualServerId + "/credentials/" + credentialType + "/" + username)
 	result := &Credential{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(vsa.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -185,7 +187,7 @@ func (vsa VirtualServerApi) GetDataTrafficMetrics(ctx context.Context, virtualSe
 	path := vsa.getPath("/virtualServers/" + virtualServerId + "/metrics/datatraffic")
 	query := v.Encode()
 	result := &DataTrafficMetricsV2{}
-	if err := doRequest(ctx, http.MethodGet, path, query, result); err != nil {
+	if err := getClient(vsa.Client).doRequest(ctx, http.MethodGet, path, query, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -202,7 +204,7 @@ func (vsa VirtualServerApi) ListTemplates(ctx context.Context, virtualServerId s
 
 	path := vsa.getPath("/virtualServers/" + virtualServerId + "/templates")
 	result := &VirtualServerTemplates{}
-	if err := doRequest(ctx, http.MethodGet, path, "", result); err != nil {
+	if err := getClient(vsa.Client).doRequest(ctx, http.MethodGet, path, "", result); err != nil {
 		return nil, err
 	}
 	return result, nil


### PR DESCRIPTION
This is a draft approach proposed in #67. 

It should be backward compatible, but I did not have much time to think about all possible cases.

This also adds an option to override `http.Client` used by the client.

Things todo:
- [ ] Add some tests using a non-global client.
- [ ] Make `baseURL` work with client struct.